### PR TITLE
Added EllipticalArc primitive with radiusX, radiusZ, start/end angle …

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,18 @@
 {
   "rust-analyzer.linkedProjects": [
-      "./main/opengeometry/Cargo.toml"
-  ]
+    "./main/opengeometry/Cargo.toml"
+  ],
+
+  // "rust-analyzer.server.extraEnv": {
+  //   "RA_MAX_MEMORY": "1536"
+  // },
+
+  // "rust-analyzer.cargo.allFeatures": false,
+  // "rust-analyzer.cargo.loadOutDirsFromCheck": false,
+  // "rust-analyzer.cargo.buildScripts.enable": false,
+
+  // "rust-analyzer.procMacro.enable": false,
+
+  // "rust-analyzer.checkOnSave": true,
+  // "rust-analyzer.checkOnSave.command": "check",
 }

--- a/main/opengeometry-three/examples-vite/index.html
+++ b/main/opengeometry-three/examples-vite/index.html
@@ -352,7 +352,7 @@
       <section id="primitives" class="og-section-card">
         <div class="og-section-head">
           <h2 class="og-section-title"><a href="#primitives" class="og-anchor">Primitives</a></h2>
-          <p class="og-section-count">5 core demos</p>
+          <p class="og-section-count">6 core demos</p>
         </div>
         <div class="og-grid">
           <article class="og-example-card">
@@ -376,6 +376,18 @@
               <span class="og-tag">Curve</span>
             </div>
             <a class="og-open" href="./primitives/curve.html">Open example</a>
+          </article>
+          <article class="og-example-card">
+            <div class="og-card-top">
+              <h3 class="og-card-title">Elliptical Arc</h3>
+            </div>
+            <p class="og-card-desc">Elliptical arc with independent X and Z radius, start, end, and segment controls.</p>
+            <div class="og-tag-row">
+              <span class="og-tag">Radius X</span>
+              <span class="og-tag">Radius Z</span>
+              <span class="og-tag">Angles</span>
+            </div>
+            <a class="og-open" href="./primitives/elliptical_arc.html">Open example</a>
           </article>
           <article class="og-example-card">
             <div class="og-card-top">

--- a/main/opengeometry-three/examples-vite/primitives/elliptical_arc.html
+++ b/main/opengeometry-three/examples-vite/primitives/elliptical_arc.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>OpenGeometry Elliptical Arc Example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Simple OpenGeometry elliptical arc example for Three.js." />
+    <meta name="author" content="Mubin" />
+  </head>
+  <body class="og-example-page">
+    <div class="og-badge-title-card">
+      <a href="../index.html" class="og-badge-title-link">Back</a>
+      <span class="og-badge-title">Elliptical Arc</span>
+    </div>
+
+    <aside class="og-controls">
+      <h3>Elliptical Arc</h3>
+      <p class="og-control-summary">
+        An elliptical arc defined by `center`, `radiusX`, `radiusZ`, `startAngle`,
+        `endAngle`, and `segments`. When radiusX equals radiusZ it becomes a circle.
+      </p>
+
+      <label class="og-control-row" data-control="radiusX">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Radius X</span>
+          <code class="og-control-value" data-value>2.2</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0.5" max="4" step="0.1" value="2.2" />
+          <input data-number type="number" min="0.5" max="4" step="0.1" value="2.2" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="radiusZ">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Radius Z</span>
+          <code class="og-control-value" data-value>1.1</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0.5" max="4" step="0.1" value="1.1" />
+          <input data-number type="number" min="0.5" max="4" step="0.1" value="1.1" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="start">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Start (deg)</span>
+          <code class="og-control-value" data-value>0</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0" max="360" step="1" value="0" />
+          <input data-number type="number" min="0" max="360" step="1" value="0" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="end">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">End (deg)</span>
+          <code class="og-control-value" data-value>270</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="1" max="360" step="1" value="270" />
+          <input data-number type="number" min="1" max="360" step="1" value="270" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="segments">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Segments</span>
+          <code class="og-control-value" data-value>64</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="8" max="96" step="1" value="64" />
+          <input data-number type="number" min="8" max="96" step="1" value="64" />
+        </div>
+      </label>
+    </aside>
+
+    <div id="app"></div>
+
+    <script type="module">
+      import "../src/styles/theme.css";
+      import * as THREE from "three";
+      import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+      import Stats from "three/examples/jsm/libs/stats.module.js";
+      import wasmUrl from "../../../opengeometry/pkg/opengeometry_bg.wasm?url";
+      import { EllipticalArc, OpenGeometry, Vector3 } from "opengeometry";
+
+      const app = document.getElementById("app");
+      if (!app) {
+        throw new Error("Missing #app container");
+      }
+
+      let config = null;
+
+      function createConfig() {
+        return {
+          center: new Vector3(0, 0, 0),
+          radiusX: 2.2,
+          radiusZ: 1.1,
+          startAngle: 0,
+          endAngle: (270 * Math.PI) / 180,
+          segments: 64,
+          color: 0x2563eb,
+        };
+      }
+
+      let ellipticalArc = null;
+
+      function formatNumber(value) {
+        return Number(value).toFixed(2).replace(/\.?0+$/, "");
+      }
+
+      function degToRad(value) {
+        return (value * Math.PI) / 180;
+      }
+
+      function radToDeg(value) {
+        return (value * 180) / Math.PI;
+      }
+
+      function mountStats() {
+        const stats = new Stats();
+        stats.showPanel(0);
+        stats.dom.style.position = "fixed";
+        stats.dom.style.left = "12px";
+        stats.dom.style.bottom = "12px";
+        stats.dom.style.top = "auto";
+        stats.dom.style.zIndex = "1000";
+        document.body.appendChild(stats.dom);
+        return stats;
+      }
+
+      function attachNumberControl(name, onChange) {
+        const row = document.querySelector(`[data-control="${name}"]`);
+        const range = row?.querySelector("[data-range]");
+        const number = row?.querySelector("[data-number]");
+        const value = row?.querySelector("[data-value]");
+
+        if (!row || !range || !number || !value) {
+          throw new Error(`Missing number control: ${name}`);
+        }
+
+        const commit = (nextValue) => {
+          const parsed = Number(nextValue);
+          if (!Number.isFinite(parsed)) {
+            return;
+          }
+
+          range.value = String(parsed);
+          number.value = String(parsed);
+          value.textContent = formatNumber(parsed);
+          onChange(parsed);
+        };
+
+        range.addEventListener("input", () => commit(range.value));
+        number.addEventListener("input", () => commit(number.value));
+        commit(range.value);
+      }
+
+      function updateEllipticalArc() {
+        if (!ellipticalArc) {
+          return;
+        }
+
+        ellipticalArc.setConfig({
+          center: config.center.clone(),
+          radiusX: config.radiusX,
+          radiusZ: config.radiusZ,
+          startAngle: config.startAngle,
+          endAngle: config.endAngle,
+          segments: Math.round(config.segments),
+          color: config.color,
+        });
+
+        console.groupCollapsed("[elliptical-arc] updated");
+        console.log("Config", config);
+        console.log("Angles (deg)", {
+          startAngle: radToDeg(config.startAngle),
+          endAngle: radToDeg(config.endAngle),
+        });
+        console.groupEnd();
+      }
+
+      async function main() {
+        const scene = new THREE.Scene();
+        scene.background = new THREE.Color(0xeef2ff);
+
+        const camera = new THREE.PerspectiveCamera(
+          55,
+          window.innerWidth / window.innerHeight,
+          0.1,
+          100
+        );
+        camera.position.set(5.5, 4, 6.5);
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        app.replaceChildren(renderer.domElement);
+
+        const stats = mountStats();
+        const controls = new OrbitControls(camera, renderer.domElement);
+        controls.enableDamping = true;
+        controls.target.set(0, 0.2, 0);
+        controls.update();
+
+        scene.add(new THREE.GridHelper(20, 20, 0x4460ff, 0xd5ddff));
+        scene.add(new THREE.AmbientLight(0xffffff, 0.8));
+
+        const light = new THREE.DirectionalLight(0xffffff, 1.1);
+        light.position.set(6, 8, 4);
+        scene.add(light);
+
+        await OpenGeometry.create({ wasmURL: wasmUrl });
+        config = createConfig();
+
+        ellipticalArc = new EllipticalArc({
+          center: config.center.clone(),
+          radiusX: config.radiusX,
+          radiusZ: config.radiusZ,
+          startAngle: config.startAngle,
+          endAngle: config.endAngle,
+          segments: Math.round(config.segments),
+          color: config.color,
+        });
+        scene.add(ellipticalArc);
+
+        attachNumberControl("radiusX", (value) => {
+          config.radiusX = value;
+          updateEllipticalArc();
+        });
+        attachNumberControl("radiusZ", (value) => {
+          config.radiusZ = value;
+          updateEllipticalArc();
+        });
+        attachNumberControl("start", (value) => {
+          config.startAngle = degToRad(value);
+          updateEllipticalArc();
+        });
+        attachNumberControl("end", (value) => {
+          config.endAngle = degToRad(value);
+          updateEllipticalArc();
+        });
+        attachNumberControl("segments", (value) => {
+          config.segments = value;
+          updateEllipticalArc();
+        });
+
+        updateEllipticalArc();
+
+        renderer.setAnimationLoop(() => {
+          stats.update();
+          controls.update();
+          renderer.render(scene, camera);
+        });
+
+        window.addEventListener("resize", () => {
+          camera.aspect = window.innerWidth / window.innerHeight;
+          camera.updateProjectionMatrix();
+          renderer.setSize(window.innerWidth, window.innerHeight);
+        });
+      }
+
+      void main();
+    </script>
+  </body>
+</html>

--- a/main/opengeometry-three/src/editor/types.ts
+++ b/main/opengeometry-three/src/editor/types.ts
@@ -219,6 +219,7 @@ export type ParametricEntityType =
   | "polyline"
   | "arc"
   | "curve"
+  | "elliptical_arc"
   | "rectangle"
   | "polygon"
   | "cuboid"

--- a/main/opengeometry-three/src/primitives/elliptical_arc.ts
+++ b/main/opengeometry-three/src/primitives/elliptical_arc.ts
@@ -1,0 +1,323 @@
+import { OGEllipticalArc, Vector3 } from "../../../opengeometry/pkg/opengeometry";
+import * as THREE from "three";
+import { getUUID } from "../utils/randomizer";
+import { Line2 } from 'three/examples/jsm/lines/Line2.js';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial.js';
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry.js';
+import {
+  clonePlacement,
+  createParametricEditCapabilities,
+} from "../editor";
+import { createFreeformGeometry } from "../freeform";
+
+/**
+ * Construction options for an elliptical arc primitive.
+ */
+export interface IEllipticalArcOptions {
+  ogid?: string;
+  center: Vector3;
+  radiusX: number;
+  radiusZ: number;
+  startAngle: number;
+  endAngle: number;
+  segments: number;
+  color: number;
+  fatLines?: boolean;
+  width?: number;
+  translation?: Vector3;
+  rotation?: Vector3;
+  scale?: Vector3;
+}
+
+/**
+ * Placement updates accepted by `EllipticalArc`.
+ */
+export interface EllipticalArcPlacementOptions {
+  translation?: Vector3;
+  rotation?: Vector3;
+  scale?: Vector3;
+}
+
+/**
+ * Partial config payload accepted by `EllipticalArc.setConfig(...)`.
+ */
+export type EllipticalArcConfigUpdate = Partial<Omit<IEllipticalArcOptions, "translation" | "rotation" | "scale">>;
+
+/**
+ * Alias for `EllipticalArc` placement updates.
+ */
+export type EllipticalArcPlacementUpdate = EllipticalArcPlacementOptions;
+
+/**
+ * EllipticalArc wrapper backed by the kernel OGEllipticalArc primitive.
+ */
+export class EllipticalArc extends THREE.Line {
+  ogid: string;
+  options: IEllipticalArcOptions = {
+    center: new Vector3(0, 0, 0),
+    radiusX: 1.0,
+    radiusZ: 0.5,
+    startAngle: 0,
+    endAngle: Math.PI * 2,
+    segments: 32,
+    color: 0x00ff00,
+    fatLines: false,
+    width: 20,
+    translation: new Vector3(0, 0, 0),
+    rotation: new Vector3(0, 0, 0),
+    scale: new Vector3(1, 1, 1),
+  };
+
+  private ellipticalArc: OGEllipticalArc;
+  private fatLine: Line2 | null = null;
+
+  set color(color: number) {
+    this.options.color = color;
+    if (this.material instanceof THREE.LineBasicMaterial) {
+      this.material.color.set(color);
+    }
+    if (this.fatLine && this.fatLine.material instanceof LineMaterial) {
+      this.fatLine.material.color.set(color);
+    }
+  }
+
+  constructor(options?: IEllipticalArcOptions) {
+    super();
+
+    this.ogid = options?.ogid ?? getUUID();
+    this.ellipticalArc = new OGEllipticalArc(this.ogid);
+
+    this.options = { ...this.options, ...options };
+    this.options.ogid = this.ogid;
+
+    this.setConfig({
+      center: this.options.center.clone(),
+      radiusX: this.options.radiusX,
+      radiusZ: this.options.radiusZ,
+      startAngle: this.options.startAngle,
+      endAngle: this.options.endAngle,
+      segments: this.options.segments,
+      color: this.options.color,
+      fatLines: this.options.fatLines,
+      width: this.options.width,
+    });
+    this.setPlacement({
+      translation: this.options.translation?.clone(),
+      rotation: this.options.rotation?.clone(),
+      scale: this.options.scale?.clone(),
+    });
+  }
+
+  validateOptions() {
+    if (!this.options) {
+      throw new Error("Options are not defined for EllipticalArc");
+    }
+  }
+
+  setConfig(options: EllipticalArcConfigUpdate) {
+    this.validateOptions();
+
+    const nextOptions = { ...this.options, ...options };
+    const geometryChanged =
+      "center" in options ||
+      "radiusX" in options ||
+      "radiusZ" in options ||
+      "segments" in options ||
+      "startAngle" in options ||
+      "endAngle" in options;
+    const renderChanged =
+      "color" in options ||
+      "fatLines" in options ||
+      "width" in options;
+
+    this.options = nextOptions;
+
+    if (geometryChanged) {
+      this.ellipticalArc.set_config(
+        nextOptions.center.clone(),
+        nextOptions.radiusX,
+        nextOptions.radiusZ,
+        nextOptions.startAngle,
+        nextOptions.endAngle,
+        nextOptions.segments
+      );
+      this.generateGeometry();
+      return;
+    }
+
+    if (renderChanged) {
+      this.updateRenderStyle();
+    }
+  }
+
+  getAnchor() {
+    const anchor = this.ellipticalArc.get_anchor();
+    return new Vector3(anchor.x, anchor.y, anchor.z);
+  }
+
+  setPlacement(placement: EllipticalArcPlacementUpdate) {
+    this.options.translation = placement.translation?.clone() ?? this.options.translation;
+    this.options.rotation = placement.rotation?.clone() ?? this.options.rotation;
+    this.options.scale = placement.scale?.clone() ?? this.options.scale;
+
+    this.ellipticalArc.set_transform(
+      this.options.translation?.clone() ?? new Vector3(0, 0, 0),
+      this.options.rotation?.clone() ?? new Vector3(0, 0, 0),
+      this.options.scale?.clone() ?? new Vector3(1, 1, 1)
+    );
+    this.generateGeometry();
+  }
+
+  setTransform(translation: Vector3, rotation: Vector3, scale: Vector3) {
+    this.setPlacement({ translation, rotation, scale });
+  }
+
+  setTranslation(translation: Vector3) {
+    this.setPlacement({ translation });
+  }
+
+  setRotation(rotation: Vector3) {
+    this.setPlacement({ rotation });
+  }
+
+  setScale(scale: Vector3) {
+    this.setPlacement({ scale });
+  }
+
+  getConfig() {
+    return this.options;
+  }
+
+  getPlacement() {
+    return clonePlacement({
+      translation: this.options.translation,
+      rotation: this.options.rotation,
+      scale: this.options.scale,
+    });
+  }
+
+  getEditCapabilities() {
+    return createParametricEditCapabilities("elliptical_arc", "curve");
+  }
+
+  canConvertToFreeform() {
+    return true;
+  }
+
+  toFreeform(id: string = this.ogid) {
+    if (!this.canConvertToFreeform()) {
+      throw new Error("This entity cannot be converted to freeform.");
+    }
+    return createFreeformGeometry(this.ellipticalArc.get_local_brep_serialized(), {
+      id,
+      placement: this.getPlacement(),
+    });
+  }
+
+  private getCurrentPositions() {
+    const attribute = this.geometry.getAttribute("position");
+    if (!attribute || attribute.itemSize !== 3) {
+      return [];
+    }
+
+    const positions = [];
+    for (let index = 0; index < attribute.count; index += 1) {
+      positions.push(
+        attribute.getX(index),
+        attribute.getY(index),
+        attribute.getZ(index)
+      );
+    }
+
+    return positions;
+  }
+
+  private updateRenderStyle(bufferData?: number[]) {
+    const positions = bufferData ?? this.getCurrentPositions();
+
+    if (this.options.fatLines) {
+      if (!this.fatLine) {
+        this.fatLine = new Line2(
+          new LineGeometry(),
+          new LineMaterial({
+            color: this.options.color,
+            linewidth: this.options.width,
+            resolution: new THREE.Vector2(window.innerWidth, window.innerHeight),
+          })
+        );
+        this.add(this.fatLine);
+      }
+
+      this.fatLine.geometry.setPositions(positions);
+      (this.fatLine.material as LineMaterial).color.set(this.options.color);
+      (this.fatLine.material as LineMaterial).linewidth = this.options.width ?? 5;
+      (this.fatLine.material as LineMaterial).resolution.set(
+        window.innerWidth,
+        window.innerHeight
+      );
+      this.fatLine.visible = true;
+    } else if (this.fatLine) {
+      this.fatLine.visible = false;
+    }
+
+    if (this.material instanceof THREE.LineBasicMaterial) {
+      this.material.color.set(this.options.color);
+      this.material.visible = !this.options.fatLines;
+    }
+  }
+
+  private generateGeometry() {
+    const bufferData = Array.from(this.ellipticalArc.get_geometry_buffer());
+
+    this.writePositionsToGeometry(this.geometry, bufferData);
+    this.geometry.computeBoundingBox();
+    this.geometry.computeBoundingSphere();
+
+    if (this.material instanceof THREE.LineBasicMaterial) {
+      this.material.color.set(this.options.color);
+    } else {
+      if (Array.isArray(this.material)) {
+        this.material.forEach((material) => material.dispose());
+      } else {
+        this.material.dispose();
+      }
+      this.material = new THREE.LineBasicMaterial({ color: this.options.color });
+    }
+
+    this.updateRenderStyle(bufferData);
+  }
+
+  getBrep() {
+    const brepData = this.ellipticalArc.get_brep_serialized();
+    if (!brepData) {
+      throw new Error("Brep data is not available for EllipticalArc");
+    }
+    return JSON.parse(brepData);
+  }
+
+  discardGeometry() {
+    this.geometry.dispose();
+  }
+
+  private writePositionsToGeometry(
+    geometry: THREE.BufferGeometry,
+    positions: number[]
+  ) {
+    const existing = geometry.getAttribute("position");
+    if (
+      !(existing instanceof THREE.BufferAttribute) ||
+      existing.itemSize !== 3 ||
+      existing.count !== positions.length / 3
+    ) {
+      geometry.setAttribute(
+        "position",
+        new THREE.Float32BufferAttribute(positions, 3)
+      );
+      return;
+    }
+
+    const array = existing.array as Float32Array;
+    array.set(positions);
+    existing.needsUpdate = true;
+  }
+}

--- a/main/opengeometry-three/src/primitives/index.ts
+++ b/main/opengeometry-three/src/primitives/index.ts
@@ -6,3 +6,4 @@ export * from './polyline';
 export * from './arc';
 export * from './rectangle';
 export * from './curve';
+export * from "./elliptical_arc";

--- a/main/opengeometry/src/lib.rs
+++ b/main/opengeometry/src/lib.rs
@@ -20,6 +20,7 @@ pub mod primitives {
     pub mod cuboid;
     pub mod curve;
     pub mod cylinder;
+    pub mod elliptical_arc;
     pub mod line;
     pub mod polygon;
     pub mod polyline;

--- a/main/opengeometry/src/primitives/elliptical_arc.rs
+++ b/main/opengeometry/src/primitives/elliptical_arc.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+use crate::brep::{Brep, BrepBuilder};
+use crate::export::projection::{project_brep_to_scene, CameraParameters, HlrOptions, Scene2D};
+use crate::spatial::placement::Placement3D;
+use openmaths::Vector3;
+use uuid::Uuid;
+
+#[wasm_bindgen]
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OGEllipticalArc {
+    id: String,
+    center: Vector3,
+    radius_x: f64,
+    radius_z: f64,
+    start_angle: f64,
+    end_angle: f64,
+    segments: u32,
+    placement: Placement3D,
+    brep: Brep,
+}
+
+#[wasm_bindgen]
+impl OGEllipticalArc {
+    #[wasm_bindgen(setter)]
+    pub fn set_id(&mut self, id: String) {
+        self.id = id;
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn id(&self) -> String {
+        self.id.clone()
+    }
+
+    #[wasm_bindgen(constructor)]
+    pub fn new(id: String) -> OGEllipticalArc {
+        let internal_id = Uuid::new_v4();
+
+        OGEllipticalArc {
+            id,
+            center: Vector3::new(0.0, 0.0, 0.0),
+            radius_x: 1.0,
+            radius_z: 0.5,
+            start_angle: 0.0,
+            end_angle: 2.0 * std::f64::consts::PI,
+            segments: 32,
+            placement: Placement3D::new(),
+            brep: Brep::new(internal_id),
+        }
+    }
+
+    #[wasm_bindgen]
+    pub fn set_config(
+        &mut self,
+        center: Vector3,
+        radius_x: f64,
+        radius_z: f64,
+        start_angle: f64,
+        end_angle: f64,
+        segments: u32,
+    ) -> Result<(), JsValue> {
+        self.center = center;
+        self.radius_x = radius_x.max(1.0e-6);
+        self.radius_z = radius_z.max(1.0e-6);
+        self.start_angle = start_angle;
+        self.end_angle = end_angle;
+        self.segments = segments.max(3);
+        self.placement.set_anchor(self.center);
+        self.generate_geometry()
+    }
+
+    #[wasm_bindgen]
+    pub fn set_center(&mut self, center: Vector3) {
+        self.center = center;
+        self.placement.set_anchor(self.center);
+    }
+
+    #[wasm_bindgen]
+    pub fn set_transform(
+        &mut self,
+        position: Vector3,
+        rotation: Vector3,
+        scale: Vector3,
+    ) -> Result<(), JsValue> {
+        self.placement
+            .set_transform(position, rotation, scale)
+            .map_err(|err| JsValue::from_str(&err))
+    }
+
+    #[wasm_bindgen]
+    pub fn set_translation(&mut self, translation: Vector3) {
+        self.placement.set_translation(translation);
+    }
+
+    #[wasm_bindgen]
+    pub fn set_rotation(&mut self, rotation: Vector3) {
+        self.placement.set_rotation(rotation);
+    }
+
+    #[wasm_bindgen]
+    pub fn set_scale(&mut self, scale: Vector3) -> Result<(), JsValue> {
+        self.placement
+            .set_scale(scale)
+            .map_err(|err| JsValue::from_str(&err))
+    }
+
+    #[wasm_bindgen]
+    pub fn generate_geometry(&mut self) -> Result<(), JsValue> {
+        let segment_count = self.segments.max(3);
+        let angle_step = (self.end_angle - self.start_angle) / segment_count as f64;
+
+        let mut points = Vec::with_capacity((segment_count + 1) as usize);
+        let mut angle = self.start_angle;
+        for _ in 0..=segment_count {
+            // Key difference from OGArc: radius_x on X axis, radius_z on Z axis
+            let x = self.radius_x * angle.cos();
+            let y = 0.0;
+            let z = self.radius_z * angle.sin();
+            points.push(Vector3::new(x, y, z));
+            angle += angle_step;
+        }
+
+        let is_closed =
+            (self.end_angle - self.start_angle).abs() >= 2.0 * std::f64::consts::PI - 1.0e-9;
+
+        // Deduplicate first and last point when closed
+        if is_closed && points.len() > 2 {
+            let first = points[0];
+            let last = *points.last().unwrap();
+            let dx = first.x - last.x;
+            let dy = first.y - last.y;
+            let dz = first.z - last.z;
+            if dx * dx + dy * dy + dz * dz <= 1.0e-12 {
+                points.pop();
+            }
+        }
+
+        let mut builder = BrepBuilder::new(self.brep.id);
+        builder.add_vertices(&points);
+
+        if points.len() >= 2 {
+            let indices: Vec<u32> = (0..points.len() as u32).collect();
+            builder
+                .add_wire(&indices, is_closed && points.len() > 2)
+                .map_err(|err| {
+                    JsValue::from_str(&format!("Failed to build elliptical arc wire: {}", err))
+                })?;
+        }
+
+        self.brep = builder.build().map_err(|err| {
+            JsValue::from_str(&format!("Failed to finalize elliptical arc BREP: {}", err))
+        })?;
+
+        Ok(())
+    }
+
+    #[wasm_bindgen]
+    pub fn dispose_points(&mut self) {
+        self.brep.clear();
+    }
+
+    #[wasm_bindgen]
+    pub fn destroy(&mut self) {
+        self.brep.clear();
+        self.id.clear();
+    }
+
+    #[wasm_bindgen]
+    pub fn get_brep_serialized(&self) -> String {
+        serde_json::to_string(&self.world_brep()).unwrap()
+    }
+
+    #[wasm_bindgen]
+    pub fn get_local_brep_serialized(&self) -> String {
+        serde_json::to_string(&self.brep).unwrap()
+    }
+
+    #[wasm_bindgen]
+    pub fn get_geometry_serialized(&self) -> String {
+        serde_json::to_string(&wire_geometry_buffer(&self.world_brep())).unwrap()
+    }
+
+    #[wasm_bindgen]
+    pub fn get_local_geometry_serialized(&self) -> String {
+        serde_json::to_string(&wire_geometry_buffer(&self.brep)).unwrap()
+    }
+
+    #[wasm_bindgen]
+    pub fn get_geometry_buffer(&self) -> Vec<f64> {
+        wire_geometry_buffer(&self.world_brep())
+    }
+
+    #[wasm_bindgen]
+    pub fn get_local_geometry_buffer(&self) -> Vec<f64> {
+        wire_geometry_buffer(&self.brep)
+    }
+
+    #[wasm_bindgen]
+    pub fn get_anchor(&self) -> Vector3 {
+        self.placement.anchor
+    }
+}
+
+impl OGEllipticalArc {
+    pub fn brep(&self) -> &Brep {
+        &self.brep
+    }
+
+    pub fn world_brep(&self) -> Brep {
+        self.brep.transformed(&self.placement)
+    }
+
+    pub fn to_projected_scene2d(&self, camera: &CameraParameters, hlr: &HlrOptions) -> Scene2D {
+        let world_brep = self.world_brep();
+        project_brep_to_scene(&world_brep, camera, hlr)
+    }
+}
+
+fn wire_geometry_buffer(brep: &Brep) -> Vec<f64> {
+    let Some(wire) = brep.wires.first() else {
+        return Vec::new();
+    };
+
+    brep.get_wire_vertex_buffer(wire.id, wire.is_closed)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "opengeometry",
-  "version": "2.0.3",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengeometry",
-      "version": "2.0.3",
-      "license": "ISC",
+      "version": "2.0.9",
+      "license": "MPL-2.0",
       "dependencies": {
         "tsc": "^2.0.4",
         "uuid": "^10.0.0"
@@ -28,7 +28,7 @@
         "vite": "^6.2.2"
       },
       "peerDependencies": {
-        "three": "^0.168.0"
+        "three": ">=0.168.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## What this adds
- New `OGEllipticalArc` Rust primitive in the kernel
- New `EllipticalArc` TypeScript wrapper following existing Arc patterns
- Example page with interactive radiusX, radiusZ, angle and segment controls

## How to test
1. npm run build
2. npm --prefix main/opengeometry-three run dev-example-three
3. Open Elliptical Arc from the examples index