### PR TITLE
feat(spatial): Add WASM-backed AABB BVH spatial index

### DIFF
--- a/docs/api/core/opengeometry.mdx
+++ b/docs/api/core/opengeometry.mdx
@@ -47,3 +47,8 @@ og.enableDebug = true;
 ## Live demo
 
 Start from the hosted demo index (all demos initialize OpenGeometry): [OpenGeometry demos](https://demo.opengeometry.io/).
+
+## Related APIs
+
+- [Spatial Index](/api/core/spatial-index) for broad-phase AABB queries
+- [Scene Management](/api/scene/scene-management) for named B-Rep scene snapshots

--- a/docs/api/core/spatial-index.mdx
+++ b/docs/api/core/spatial-index.mdx
@@ -1,0 +1,159 @@
+---
+title: Spatial Index
+description: Query AABB bounds with the OGSpatialIndex broad-phase API
+---
+
+`OGSpatialIndex` is a WASM-backed AABB BVH. It accepts application-provided bounds and returns item
+IDs for broad-phase queries.
+
+<Note>
+Initialize the runtime once before creating an index:
+
+```ts
+import { OpenGeometry } from "opengeometry";
+
+await OpenGeometry.create({ wasmURL: "/opengeometry_bg.wasm" });
+```
+</Note>
+
+## Create an Index
+
+### fromFlatArrays()
+
+Builds an index from typed arrays. This is the preferred path for large scenes because it avoids
+JSON parsing.
+
+```ts
+import { OGSpatialIndex } from "opengeometry";
+
+const ids = new Uint32Array([1, 2]);
+const bounds = new Float64Array([
+  0, 0, 0, 1, 1, 1,
+  4, 0, 0, 5, 1, 1,
+]);
+
+const index = OGSpatialIndex.fromFlatArrays(ids, bounds);
+```
+
+<ParamField path="ids" type="Uint32Array">
+  Item IDs returned by queries.
+</ParamField>
+
+<ParamField path="bounds" type="Float64Array">
+  Flat AABB values in `[minX, minY, minZ, maxX, maxY, maxZ]` order for each ID.
+</ParamField>
+
+### constructor()
+
+Builds an index from a JSON string. This path is convenient for small payloads and tests.
+
+```ts
+const index = new OGSpatialIndex(JSON.stringify([
+  { id: 1, min: [0, 0, 0], max: [1, 1, 1] },
+  { id: 2, min: [4, 0, 0], max: [5, 1, 1] },
+]));
+```
+
+## Inspect the Index
+
+### primitiveCount()
+
+Returns the number of indexed AABBs.
+
+```ts
+const count = index.primitiveCount();
+```
+
+### nodeCount()
+
+Returns the number of BVH nodes.
+
+```ts
+const nodes = index.nodeCount();
+```
+
+## Query AABBs
+
+### queryAabbIds()
+
+Returns a `Uint32Array` of IDs whose bounds intersect the query bounds.
+
+```ts
+const ids = index.queryAabbIds(0, 0, 0, 2, 2, 2);
+console.log([...ids]);
+```
+
+### queryAabb()
+
+Returns the same result as a JSON string.
+
+```ts
+const ids = JSON.parse(index.queryAabb(0, 0, 0, 2, 2, 2));
+```
+
+## Query Frustums
+
+### queryFrustumIds()
+
+Returns a `Uint32Array` of IDs whose bounds intersect the supplied frustum.
+
+Frustum planes use `{ normal: [x, y, z], constant }`, where a point is inside the plane when:
+
+```ts
+normal.x * point.x + normal.y * point.y + normal.z * point.z + constant >= 0
+```
+
+```ts
+const planes = JSON.stringify([
+  { normal: [1, 0, 0], constant: 0 },
+  { normal: [-1, 0, 0], constant: 10 },
+  { normal: [0, 1, 0], constant: 0 },
+  { normal: [0, -1, 0], constant: 10 },
+  { normal: [0, 0, 1], constant: 0 },
+  { normal: [0, 0, -1], constant: 10 },
+]);
+
+const ids = index.queryFrustumIds(planes);
+```
+
+### queryFrustum()
+
+Returns the same result as a JSON string.
+
+```ts
+const ids = JSON.parse(index.queryFrustum(planes));
+```
+
+## Raycast Bounds
+
+### raycastFirst()
+
+Returns the nearest intersected AABB as JSON, or `null` if no bounds are hit.
+
+```ts
+const hit = JSON.parse(index.raycastFirst(
+  0, 0.5, 0.5,
+  1, 0, 0,
+  100,
+));
+```
+
+<Warning>
+This is a broad-phase ray query against bounding boxes. It does not test mesh triangles or B-Rep
+faces.
+</Warning>
+
+## Errors
+
+The index rejects:
+
+- non-finite coordinates
+- bounds where `min > max`
+- flat arrays whose bounds length is not `ids.length * 6`
+- frustum planes with zero normals
+- rays with zero direction or negative max distance
+
+## Related Reading
+
+- [Spatial Index concept](/concepts/spatial-index)
+- [Scene Management](/api/scene/scene-management)

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -29,6 +29,7 @@ The architecture consists of three primary layers:
 │   • Primitives                          │
 │   • Operations                          │
 │   • BREP                                │
+│   • Spatial queries                     │
 │   • Export                              │
 └─────────────────────────────────────────┘
 ```
@@ -69,6 +70,10 @@ The Rust core is organized into focused modules as defined in `src/lib.rs`:
 
 **booleans**
 - Kernel-backed boolean operations (union, intersection, subtraction)
+
+**spatial**
+- `placement` - Translation, rotation, and scale transforms for kernel-backed geometry
+- `bvh` - AABB spatial index for broad-phase scene queries
 
 **brep**
 Boundary representation data structures:
@@ -186,6 +191,7 @@ Secondary target for server-side use:
 - **Rust Core**: Near-native performance, memory-safe
 - **WASM Overhead**: Minimal for compute-heavy operations
 - **Serialization**: JSON for complex types, typed arrays for vertex data
+- **Spatial Queries**: AABB BVH queries for broad-phase culling and candidate selection
 - **Three.js Integration**: Efficient mesh creation from BREP output
 
 ## Next Steps
@@ -196,5 +202,8 @@ Secondary target for server-side use:
   </Card>
   <Card title="Scene Graph" icon="sitemap" href="/concepts/scene-graph">
     Understand multi-entity scene management
+  </Card>
+  <Card title="Spatial Index" icon="magnifying-glass" href="/concepts/spatial-index">
+    Learn how to query large sets of scene bounds
   </Card>
 </CardGroup>

--- a/docs/concepts/spatial-index.mdx
+++ b/docs/concepts/spatial-index.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Spatial Index'
+description: 'Broad-phase scene queries with a WASM-backed AABB BVH'
+---
+
+OpenGeometry includes a lightweight spatial index for broad-phase scene queries. It stores
+application-provided axis-aligned bounding boxes (AABBs) in a bounding volume hierarchy (BVH) and
+answers coarse AABB, frustum, and ray queries inside the WASM kernel.
+
+Use it when your application already has object, chunk, or entity bounds and needs to reduce a large
+set to a smaller candidate list before doing more expensive work.
+
+## What It Solves
+
+The spatial index is designed for:
+
+- view-frustum candidate culling
+- broad-phase picking before exact geometry tests
+- object or chunk visibility queries
+- fast overlap checks for many scene items
+
+It is not a triangle-level mesh acceleration structure. `raycastFirst(...)` returns the nearest
+intersected bounding box, not the nearest triangle on a mesh. Applications that need exact picking
+should use the result as a candidate set and then run a narrow-phase test against their own geometry
+or a future triangle BVH.
+
+## Data Model
+
+Each indexed item has:
+
+- a numeric `id`
+- a minimum AABB corner `[x, y, z]`
+- a maximum AABB corner `[x, y, z]`
+
+The index does not own B-Reps, Three.js objects, scene graph entities, or mesh buffers. This keeps it
+usable from different downstream scene systems without making the B-Rep or renderer layers maintain a
+second source of geometry truth.
+
+## Runtime Flow
+
+1. Initialize OpenGeometry once.
+2. Build an `OGSpatialIndex` from item bounds.
+3. Query it with an AABB, frustum plane set, or ray.
+4. Use the returned IDs to look up your application objects.
+
+```ts
+import { OGSpatialIndex, OpenGeometry } from "opengeometry";
+
+await OpenGeometry.create({ wasmURL: "/opengeometry_bg.wasm" });
+
+const ids = new Uint32Array([101, 102, 103]);
+const bounds = new Float64Array([
+  0, 0, 0, 2, 2, 2,
+  8, 0, 0, 10, 2, 2,
+  0, 0, 8, 2, 2, 10,
+]);
+
+const index = OGSpatialIndex.fromFlatArrays(ids, bounds);
+const visibleIds = index.queryAabbIds(-1, -1, -1, 3, 3, 3);
+
+console.log([...visibleIds]); // [101]
+```
+
+## Why It Lives in the Kernel
+
+`OGSpatialIndex` is a geometry-adjacent primitive rather than an application workflow. It belongs in
+the core because the same broad-phase index is useful for scene export, viewport culling, picking
+candidates, and downstream AEC/BIM tools.
+
+Downstream packages can still decide when to rebuild the index, how to map IDs back to application
+objects, and which exact narrow-phase test to run after the broad-phase query.
+
+## Limits
+
+- Bounds must be finite and axis-aligned.
+- The index is immutable after construction; rebuild it when item bounds change.
+- Ray queries intersect AABBs only.
+- Frustum queries accept plane equations and return items whose bounds intersect the frustum.
+- This does not replace B-Rep topology, exact boolean operations, or renderer-specific mesh BVHs.
+
+## Related Reading
+
+- [Spatial Index API](/api/core/spatial-index)
+- [Scene Graph](/concepts/scene-graph)
+- [Architecture Overview](/concepts/architecture)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
               "concepts/operations",
               "concepts/brep",
               "concepts/booleans",
+              "concepts/spatial-index",
               "concepts/exports"
             ]
           },
@@ -76,7 +77,8 @@
           {
             "group": "Core",
             "pages": [
-              "api/core/opengeometry"
+              "api/core/opengeometry",
+              "api/core/spatial-index"
             ]
           },
           {

--- a/main/opengeometry-three/index.ts
+++ b/main/opengeometry-three/index.ts
@@ -3,6 +3,7 @@
  */
 import init, {
   OGSceneManager,
+  OGSpatialIndex,
   Vector3,
 } from "../opengeometry/pkg/opengeometry";
 import { SpotLabel } from "./src/markup/spotMarker";
@@ -105,6 +106,11 @@ export class OpenGeometry {
  * export, and other scene-level workflows.
  */
 export { OGSceneManager };
+
+/**
+ * WASM-backed AABB spatial index for broad-phase scene queries.
+ */
+export { OGSpatialIndex };
 
 /**
  * Shared wasm-backed vector type used throughout the public API.

--- a/main/opengeometry/src/lib.rs
+++ b/main/opengeometry/src/lib.rs
@@ -36,6 +36,7 @@ pub mod primitives {
 }
 
 pub mod spatial {
+    pub mod bvh;
     pub mod placement;
     pub mod workplane;
 }

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -1,0 +1,776 @@
+use std::cmp::Ordering;
+
+use openmaths::Vector3;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+const BVH_LEAF_SIZE: usize = 8;
+const RAY_EPSILON: f64 = 1.0e-12;
+
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct Aabb3 {
+    pub min: Vector3,
+    pub max: Vector3,
+}
+
+impl Aabb3 {
+    pub fn new(min: Vector3, max: Vector3) -> Result<Self, String> {
+        validate_vector3(min, "AABB min")?;
+        validate_vector3(max, "AABB max")?;
+
+        if min.x > max.x || min.y > max.y || min.z > max.z {
+            return Err(
+                "Invalid AABB: min components must be less than or equal to max components."
+                    .to_string(),
+            );
+        }
+
+        Ok(Self { min, max })
+    }
+
+    pub fn from_coords(
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Result<Self, String> {
+        Self::new(
+            Vector3::new(min_x, min_y, min_z),
+            Vector3::new(max_x, max_y, max_z),
+        )
+    }
+
+    pub fn from_flat_vertices(vertices: &[f64]) -> Result<Option<Self>, String> {
+        if vertices.is_empty() {
+            return Ok(None);
+        }
+
+        if vertices.len() % 3 != 0 {
+            return Err(
+                "Invalid vertex buffer: flat vertex arrays must contain 3 values per vertex."
+                    .to_string(),
+            );
+        }
+
+        let mut min = Vector3::new(vertices[0], vertices[1], vertices[2]);
+        let mut max = min;
+        validate_vector3(min, "vertex")?;
+
+        for vertex in vertices.chunks_exact(3).skip(1) {
+            let point = Vector3::new(vertex[0], vertex[1], vertex[2]);
+            validate_vector3(point, "vertex")?;
+            min.x = min.x.min(point.x);
+            min.y = min.y.min(point.y);
+            min.z = min.z.min(point.z);
+            max.x = max.x.max(point.x);
+            max.y = max.y.max(point.y);
+            max.z = max.z.max(point.z);
+        }
+
+        Ok(Some(Self { min, max }))
+    }
+
+    pub fn union(&self, other: &Self) -> Self {
+        Self {
+            min: Vector3::new(
+                self.min.x.min(other.min.x),
+                self.min.y.min(other.min.y),
+                self.min.z.min(other.min.z),
+            ),
+            max: Vector3::new(
+                self.max.x.max(other.max.x),
+                self.max.y.max(other.max.y),
+                self.max.z.max(other.max.z),
+            ),
+        }
+    }
+
+    pub fn center(&self) -> Vector3 {
+        Vector3::new(
+            (self.min.x + self.max.x) * 0.5,
+            (self.min.y + self.max.y) * 0.5,
+            (self.min.z + self.max.z) * 0.5,
+        )
+    }
+
+    pub fn extent(&self) -> Vector3 {
+        Vector3::new(
+            self.max.x - self.min.x,
+            self.max.y - self.min.y,
+            self.max.z - self.min.z,
+        )
+    }
+
+    pub fn intersects_aabb(&self, other: &Self) -> bool {
+        self.min.x <= other.max.x
+            && self.max.x >= other.min.x
+            && self.min.y <= other.max.y
+            && self.max.y >= other.min.y
+            && self.min.z <= other.max.z
+            && self.max.z >= other.min.z
+    }
+
+    pub fn intersects_frustum(&self, frustum: &Frustum3) -> bool {
+        frustum
+            .planes
+            .iter()
+            .all(|plane| plane.distance_to_point(self.positive_vertex(plane.normal)) >= 0.0)
+    }
+
+    pub fn intersects_ray(&self, ray: &Ray3) -> Option<f64> {
+        let mut t_min = 0.0;
+        let mut t_max = ray.max_distance;
+
+        update_ray_interval(
+            ray.origin.x,
+            ray.direction.x,
+            self.min.x,
+            self.max.x,
+            &mut t_min,
+            &mut t_max,
+        )?;
+        update_ray_interval(
+            ray.origin.y,
+            ray.direction.y,
+            self.min.y,
+            self.max.y,
+            &mut t_min,
+            &mut t_max,
+        )?;
+        update_ray_interval(
+            ray.origin.z,
+            ray.direction.z,
+            self.min.z,
+            self.max.z,
+            &mut t_min,
+            &mut t_max,
+        )?;
+
+        Some(t_min)
+    }
+
+    fn longest_axis(&self) -> Axis3 {
+        let extent = self.extent();
+        if extent.x >= extent.y && extent.x >= extent.z {
+            Axis3::X
+        } else if extent.y >= extent.z {
+            Axis3::Y
+        } else {
+            Axis3::Z
+        }
+    }
+
+    fn positive_vertex(&self, normal: Vector3) -> Vector3 {
+        Vector3::new(
+            if normal.x >= 0.0 {
+                self.max.x
+            } else {
+                self.min.x
+            },
+            if normal.y >= 0.0 {
+                self.max.y
+            } else {
+                self.min.y
+            },
+            if normal.z >= 0.0 {
+                self.max.z
+            } else {
+                self.min.z
+            },
+        )
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Plane3 {
+    normal: Vector3,
+    constant: f64,
+}
+
+impl Plane3 {
+    pub fn new(normal: Vector3, constant: f64) -> Result<Self, String> {
+        validate_vector3(normal, "frustum plane normal")?;
+        if !constant.is_finite() {
+            return Err("Invalid frustum plane: constant must be finite.".to_string());
+        }
+
+        let length_squared = normal.x * normal.x + normal.y * normal.y + normal.z * normal.z;
+        if length_squared <= RAY_EPSILON {
+            return Err("Invalid frustum plane: normal must be non-zero.".to_string());
+        }
+
+        Ok(Self { normal, constant })
+    }
+
+    fn distance_to_point(&self, point: Vector3) -> f64 {
+        self.normal.x * point.x + self.normal.y * point.y + self.normal.z * point.z + self.constant
+    }
+}
+
+pub struct Frustum3 {
+    planes: Vec<Plane3>,
+}
+
+impl Frustum3 {
+    pub fn new(planes: Vec<Plane3>) -> Result<Self, String> {
+        if planes.is_empty() {
+            return Err("Invalid frustum: at least one plane is required.".to_string());
+        }
+
+        Ok(Self { planes })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct Ray3 {
+    origin: Vector3,
+    direction: Vector3,
+    max_distance: f64,
+}
+
+impl Ray3 {
+    pub fn new(origin: Vector3, direction: Vector3, max_distance: f64) -> Result<Self, String> {
+        validate_vector3(origin, "ray origin")?;
+        validate_vector3(direction, "ray direction")?;
+        if !max_distance.is_finite() || max_distance < 0.0 {
+            return Err(
+                "Invalid ray: max distance must be a finite non-negative number.".to_string(),
+            );
+        }
+
+        let length_squared =
+            direction.x * direction.x + direction.y * direction.y + direction.z * direction.z;
+        if length_squared <= RAY_EPSILON {
+            return Err("Invalid ray: direction must be non-zero.".to_string());
+        }
+
+        let inv_length = 1.0 / length_squared.sqrt();
+        Ok(Self {
+            origin,
+            direction: Vector3::new(
+                direction.x * inv_length,
+                direction.y * inv_length,
+                direction.z * inv_length,
+            ),
+            max_distance,
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct BvhPrimitive {
+    pub id: u32,
+    pub bounds: Aabb3,
+}
+
+impl BvhPrimitive {
+    pub fn new(id: u32, bounds: Aabb3) -> Self {
+        Self { id, bounds }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+pub struct RayHit {
+    pub id: u32,
+    pub distance: f64,
+}
+
+pub struct Bvh3 {
+    primitives: Vec<BvhPrimitive>,
+    indices: Vec<usize>,
+    nodes: Vec<BvhNode>,
+}
+
+impl Bvh3 {
+    pub fn build(primitives: Vec<BvhPrimitive>) -> Self {
+        let mut indices = (0..primitives.len()).collect::<Vec<_>>();
+        let mut nodes = Vec::new();
+
+        if !indices.is_empty() {
+            build_node(&mut indices, 0, &primitives, &mut nodes);
+        }
+
+        Self {
+            primitives,
+            indices,
+            nodes,
+        }
+    }
+
+    pub fn primitive_count(&self) -> usize {
+        self.primitives.len()
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    pub fn query_aabb(&self, bounds: &Aabb3) -> Vec<u32> {
+        self.query(|candidate| candidate.intersects_aabb(bounds))
+    }
+
+    pub fn query_frustum(&self, frustum: &Frustum3) -> Vec<u32> {
+        self.query(|candidate| candidate.intersects_frustum(frustum))
+    }
+
+    pub fn raycast_first(&self, ray: &Ray3) -> Option<RayHit> {
+        if self.nodes.is_empty() {
+            return None;
+        }
+
+        let mut closest: Option<RayHit> = None;
+        let mut stack = vec![0usize];
+
+        while let Some(node_index) = stack.pop() {
+            let node = &self.nodes[node_index];
+            let Some(node_distance) = node.bounds.intersects_ray(ray) else {
+                continue;
+            };
+
+            if closest.is_some_and(|hit| node_distance > hit.distance) {
+                continue;
+            }
+
+            if node.is_leaf() {
+                for primitive_index in &self.indices[node.start..node.end] {
+                    let primitive = &self.primitives[*primitive_index];
+                    let Some(distance) = primitive.bounds.intersects_ray(ray) else {
+                        continue;
+                    };
+
+                    if closest.is_none_or(|hit| {
+                        distance < hit.distance
+                            || (distance == hit.distance && primitive.id < hit.id)
+                    }) {
+                        closest = Some(RayHit {
+                            id: primitive.id,
+                            distance,
+                        });
+                    }
+                }
+            } else {
+                if let Some(left) = node.left {
+                    stack.push(left);
+                }
+                if let Some(right) = node.right {
+                    stack.push(right);
+                }
+            }
+        }
+
+        closest
+    }
+
+    fn query<F>(&self, intersects: F) -> Vec<u32>
+    where
+        F: Fn(&Aabb3) -> bool,
+    {
+        if self.nodes.is_empty() {
+            return Vec::new();
+        }
+
+        let mut hits = Vec::new();
+        let mut stack = vec![0usize];
+
+        while let Some(node_index) = stack.pop() {
+            let node = &self.nodes[node_index];
+            if !intersects(&node.bounds) {
+                continue;
+            }
+
+            if node.is_leaf() {
+                for primitive_index in &self.indices[node.start..node.end] {
+                    let primitive = &self.primitives[*primitive_index];
+                    if intersects(&primitive.bounds) {
+                        hits.push(primitive.id);
+                    }
+                }
+            } else {
+                if let Some(left) = node.left {
+                    stack.push(left);
+                }
+                if let Some(right) = node.right {
+                    stack.push(right);
+                }
+            }
+        }
+
+        hits
+    }
+}
+
+#[wasm_bindgen]
+pub struct OGSpatialIndex {
+    bvh: Bvh3,
+}
+
+#[wasm_bindgen]
+impl OGSpatialIndex {
+    #[wasm_bindgen(constructor)]
+    pub fn new(items_json: String) -> Result<OGSpatialIndex, JsValue> {
+        let items: Vec<SpatialIndexItemPayload> =
+            serde_json::from_str(&items_json).map_err(|err| {
+                JsValue::from_str(&format!("Invalid spatial index items JSON: {}", err))
+            })?;
+
+        let primitives = items
+            .into_iter()
+            .map(|item| {
+                Aabb3::from_coords(
+                    item.min[0],
+                    item.min[1],
+                    item.min[2],
+                    item.max[0],
+                    item.max[1],
+                    item.max[2],
+                )
+                .map(|bounds| BvhPrimitive::new(item.id, bounds))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| JsValue::from_str(&err))?;
+
+        Ok(Self {
+            bvh: Bvh3::build(primitives),
+        })
+    }
+
+    #[wasm_bindgen(js_name = primitiveCount)]
+    pub fn primitive_count(&self) -> usize {
+        self.bvh.primitive_count()
+    }
+
+    #[wasm_bindgen(js_name = nodeCount)]
+    pub fn node_count(&self) -> usize {
+        self.bvh.node_count()
+    }
+
+    #[wasm_bindgen(js_name = queryAabb)]
+    pub fn query_aabb(
+        &self,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Result<String, JsValue> {
+        let bounds = Aabb3::from_coords(min_x, min_y, min_z, max_x, max_y, max_z)
+            .map_err(|err| JsValue::from_str(&err))?;
+        serialize_ids(self.bvh.query_aabb(&bounds))
+    }
+
+    #[wasm_bindgen(js_name = queryFrustum)]
+    pub fn query_frustum(&self, planes_json: String) -> Result<String, JsValue> {
+        let frustum = parse_frustum_json(&planes_json).map_err(|err| JsValue::from_str(&err))?;
+        serialize_ids(self.bvh.query_frustum(&frustum))
+    }
+
+    #[wasm_bindgen(js_name = raycastFirst)]
+    pub fn raycast_first(
+        &self,
+        origin_x: f64,
+        origin_y: f64,
+        origin_z: f64,
+        direction_x: f64,
+        direction_y: f64,
+        direction_z: f64,
+        max_distance: f64,
+    ) -> Result<String, JsValue> {
+        let ray = Ray3::new(
+            Vector3::new(origin_x, origin_y, origin_z),
+            Vector3::new(direction_x, direction_y, direction_z),
+            max_distance,
+        )
+        .map_err(|err| JsValue::from_str(&err))?;
+
+        serde_json::to_string(&self.bvh.raycast_first(&ray))
+            .map_err(|err| JsValue::from_str(&format!("Failed to serialize raycast hit: {}", err)))
+    }
+}
+
+#[derive(Deserialize)]
+struct SpatialIndexItemPayload {
+    id: u32,
+    min: [f64; 3],
+    max: [f64; 3],
+}
+
+#[derive(Deserialize)]
+struct PlanePayload {
+    normal: [f64; 3],
+    constant: f64,
+}
+
+#[derive(Clone, Copy)]
+struct BvhNode {
+    bounds: Aabb3,
+    left: Option<usize>,
+    right: Option<usize>,
+    start: usize,
+    end: usize,
+}
+
+impl BvhNode {
+    fn is_leaf(&self) -> bool {
+        self.left.is_none() && self.right.is_none()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Axis3 {
+    X,
+    Y,
+    Z,
+}
+
+fn build_node(
+    indices: &mut [usize],
+    range_start: usize,
+    primitives: &[BvhPrimitive],
+    nodes: &mut Vec<BvhNode>,
+) -> usize {
+    let bounds = bounds_for_indices(indices, primitives);
+    let node_index = nodes.len();
+    nodes.push(BvhNode {
+        bounds,
+        left: None,
+        right: None,
+        start: range_start,
+        end: range_start + indices.len(),
+    });
+
+    if indices.len() <= BVH_LEAF_SIZE {
+        return node_index;
+    }
+
+    let axis = bounds.longest_axis();
+    indices.sort_by(|lhs, rhs| {
+        center_axis(primitives[*lhs].bounds.center(), axis)
+            .partial_cmp(&center_axis(primitives[*rhs].bounds.center(), axis))
+            .unwrap_or(Ordering::Equal)
+    });
+
+    let mid = indices.len() / 2;
+    let (left_indices, right_indices) = indices.split_at_mut(mid);
+    let left = build_node(left_indices, range_start, primitives, nodes);
+    let right = build_node(right_indices, range_start + mid, primitives, nodes);
+
+    nodes[node_index].left = Some(left);
+    nodes[node_index].right = Some(right);
+    node_index
+}
+
+fn bounds_for_indices(indices: &[usize], primitives: &[BvhPrimitive]) -> Aabb3 {
+    let mut bounds = primitives[indices[0]].bounds;
+    for index in &indices[1..] {
+        bounds = bounds.union(&primitives[*index].bounds);
+    }
+    bounds
+}
+
+fn center_axis(center: Vector3, axis: Axis3) -> f64 {
+    match axis {
+        Axis3::X => center.x,
+        Axis3::Y => center.y,
+        Axis3::Z => center.z,
+    }
+}
+
+fn parse_frustum_json(planes_json: &str) -> Result<Frustum3, String> {
+    let planes: Vec<PlanePayload> = serde_json::from_str(planes_json)
+        .map_err(|err| format!("Invalid frustum planes JSON: {}", err))?;
+
+    let planes = planes
+        .into_iter()
+        .map(|plane| {
+            Plane3::new(
+                Vector3::new(plane.normal[0], plane.normal[1], plane.normal[2]),
+                plane.constant,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Frustum3::new(planes)
+}
+
+fn serialize_ids(ids: Vec<u32>) -> Result<String, JsValue> {
+    serde_json::to_string(&ids).map_err(|err| {
+        JsValue::from_str(&format!("Failed to serialize spatial query ids: {}", err))
+    })
+}
+
+fn update_ray_interval(
+    origin: f64,
+    direction: f64,
+    min: f64,
+    max: f64,
+    t_min: &mut f64,
+    t_max: &mut f64,
+) -> Option<()> {
+    if direction.abs() <= RAY_EPSILON {
+        return (origin >= min && origin <= max).then_some(());
+    }
+
+    let inv_direction = 1.0 / direction;
+    let mut near = (min - origin) * inv_direction;
+    let mut far = (max - origin) * inv_direction;
+
+    if near > far {
+        std::mem::swap(&mut near, &mut far);
+    }
+
+    *t_min = (*t_min).max(near);
+    *t_max = (*t_max).min(far);
+
+    (t_min <= t_max).then_some(())
+}
+
+fn validate_vector3(vector: Vector3, label: &str) -> Result<(), String> {
+    if vector.x.is_finite() && vector.y.is_finite() && vector.z.is_finite() {
+        Ok(())
+    } else {
+        Err(format!("Invalid {}: all components must be finite.", label))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn box_primitive(id: u32, min: (f64, f64, f64), max: (f64, f64, f64)) -> BvhPrimitive {
+        BvhPrimitive::new(
+            id,
+            Aabb3::from_coords(min.0, min.1, min.2, max.0, max.1, max.2)
+                .expect("valid test bounds"),
+        )
+    }
+
+    fn sorted(mut ids: Vec<u32>) -> Vec<u32> {
+        ids.sort_unstable();
+        ids
+    }
+
+    fn test_frustum() -> Frustum3 {
+        Frustum3::new(vec![
+            Plane3::new(Vector3::new(1.0, 0.0, 0.0), 0.0).expect("left plane"),
+            Plane3::new(Vector3::new(-1.0, 0.0, 0.0), 10.0).expect("right plane"),
+            Plane3::new(Vector3::new(0.0, 1.0, 0.0), 0.0).expect("bottom plane"),
+            Plane3::new(Vector3::new(0.0, -1.0, 0.0), 10.0).expect("top plane"),
+            Plane3::new(Vector3::new(0.0, 0.0, 1.0), 0.0).expect("near plane"),
+            Plane3::new(Vector3::new(0.0, 0.0, -1.0), 10.0).expect("far plane"),
+        ])
+        .expect("valid frustum")
+    }
+
+    #[test]
+    fn flat_vertices_create_bounds_and_reject_invalid_buffers() {
+        let bounds = Aabb3::from_flat_vertices(&[-1.0, 2.0, 3.0, 4.0, -5.0, 6.0, 0.5, 1.0, -7.0])
+            .expect("valid vertex buffer")
+            .expect("non-empty bounds");
+
+        assert_eq!(bounds.min.x, -1.0);
+        assert_eq!(bounds.min.y, -5.0);
+        assert_eq!(bounds.min.z, -7.0);
+        assert_eq!(bounds.max.x, 4.0);
+        assert_eq!(bounds.max.y, 2.0);
+        assert_eq!(bounds.max.z, 6.0);
+
+        assert!(Aabb3::from_flat_vertices(&[])
+            .expect("empty is valid")
+            .is_none());
+        assert!(Aabb3::from_flat_vertices(&[1.0, 2.0]).is_err());
+    }
+
+    #[test]
+    fn bvh_queries_aabb_without_scanning_unrelated_bounds() {
+        let bvh = Bvh3::build(vec![
+            box_primitive(1, (-5.0, 0.0, 0.0), (-4.0, 1.0, 1.0)),
+            box_primitive(2, (1.0, 1.0, 1.0), (2.0, 2.0, 2.0)),
+            box_primitive(3, (3.0, 3.0, 3.0), (4.0, 4.0, 4.0)),
+            box_primitive(4, (20.0, 0.0, 0.0), (21.0, 1.0, 1.0)),
+        ]);
+
+        assert_eq!(bvh.primitive_count(), 4);
+        assert_eq!(bvh.node_count(), 1);
+
+        let query = Aabb3::from_coords(0.0, 0.0, 0.0, 3.5, 3.5, 3.5).expect("valid query bounds");
+        assert_eq!(sorted(bvh.query_aabb(&query)), vec![2, 3]);
+    }
+
+    #[test]
+    fn bvh_builds_internal_nodes_for_large_sets_and_queries_frustum() {
+        let primitives = (0..32)
+            .map(|index| {
+                let x = index as f64 * 2.0;
+                box_primitive(index, (x, 0.0, 0.0), (x + 0.5, 0.5, 0.5))
+            })
+            .collect::<Vec<_>>();
+        let bvh = Bvh3::build(primitives);
+
+        assert_eq!(bvh.primitive_count(), 32);
+        assert!(bvh.node_count() > 1);
+
+        assert_eq!(
+            sorted(bvh.query_frustum(&test_frustum())),
+            vec![0, 1, 2, 3, 4, 5]
+        );
+    }
+
+    #[test]
+    fn raycast_first_returns_nearest_intersection() {
+        let bvh = Bvh3::build(vec![
+            box_primitive(10, (5.0, -1.0, -1.0), (6.0, 1.0, 1.0)),
+            box_primitive(20, (2.0, -1.0, -1.0), (3.0, 1.0, 1.0)),
+        ]);
+        let ray = Ray3::new(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(10.0, 0.0, 0.0),
+            100.0,
+        )
+        .expect("valid ray");
+
+        let hit = bvh.raycast_first(&ray).expect("nearest hit");
+        assert_eq!(hit.id, 20);
+        assert_eq!(hit.distance, 2.0);
+    }
+
+    #[test]
+    fn wasm_spatial_index_queries_aabb_frustum_and_ray() {
+        let items = r#"[
+            {"id": 1, "min": [-2, 0, 0], "max": [-1, 1, 1]},
+            {"id": 2, "min": [2, 2, 2], "max": [3, 3, 3]},
+            {"id": 3, "min": [6, 0, 0], "max": [7, 1, 1]}
+        ]"#;
+        let index = OGSpatialIndex::new(items.to_string()).expect("valid index");
+        assert_eq!(index.primitive_count(), 3);
+
+        let ids = index
+            .query_aabb(0.0, 0.0, 0.0, 4.0, 4.0, 4.0)
+            .expect("query ids");
+        assert_eq!(ids, "[2]");
+
+        let frustum_json = r#"[
+            {"normal": [1, 0, 0], "constant": 0},
+            {"normal": [-1, 0, 0], "constant": 10},
+            {"normal": [0, 1, 0], "constant": 0},
+            {"normal": [0, -1, 0], "constant": 10},
+            {"normal": [0, 0, 1], "constant": 0},
+            {"normal": [0, 0, -1], "constant": 10}
+        ]"#;
+        let mut frustum_ids = serde_json::from_str::<Vec<u32>>(
+            &index
+                .query_frustum(frustum_json.to_string())
+                .expect("frustum ids"),
+        )
+        .expect("valid frustum ids");
+        frustum_ids.sort_unstable();
+        assert_eq!(frustum_ids, vec![2, 3]);
+
+        let ray_hit = index
+            .raycast_first(0.0, 2.5, 2.5, 1.0, 0.0, 0.0, 100.0)
+            .expect("raycast hit");
+        assert_eq!(ray_hit, r#"{"id":2,"distance":2.0}"#);
+    }
+}

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -848,6 +848,39 @@ mod tests {
     }
 
     #[test]
+    fn raycast_handles_parallel_slabs_and_max_distance_edges() {
+        let bvh = Bvh3::build(vec![box_primitive(20, (1.0, -1.0, -1.0), (2.0, 1.0, 1.0))]);
+
+        let parallel_outside = Ray3::new(
+            Vector3::new(0.0, -5.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            10.0,
+        )
+        .expect("valid ray");
+        assert!(bvh.raycast_first(&parallel_outside).is_none());
+
+        let parallel_inside = Ray3::new(
+            Vector3::new(1.5, -5.0, 0.0),
+            Vector3::new(0.0, 1.0, 0.0),
+            10.0,
+        )
+        .expect("valid ray");
+        let hit = bvh
+            .raycast_first(&parallel_inside)
+            .expect("parallel slab hit");
+        assert_eq!(hit.id, 20);
+        assert_eq!(hit.distance, 4.0);
+
+        let clipped_before_entry = Ray3::new(
+            Vector3::new(3.0, 0.0, 0.0),
+            Vector3::new(-1.0e-13, 1.0, 0.0),
+            9.0e12,
+        )
+        .expect("valid long ray");
+        assert!(bvh.raycast_first(&clipped_before_entry).is_none());
+    }
+
+    #[test]
     fn wasm_spatial_index_queries_aabb_frustum_and_ray() {
         let items = r#"[
             {"id": 1, "min": [-2, 0, 0], "max": [-1, 1, 1]},

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -678,7 +678,7 @@ fn update_ray_interval(
     t_min: &mut f64,
     t_max: &mut f64,
 ) -> Option<()> {
-    if direction.abs() <= RAY_EPSILON {
+    if direction == 0.0 {
         return (origin >= min && origin <= max).then_some(());
     }
 
@@ -824,6 +824,27 @@ mod tests {
             100.0,
         )
         .is_err());
+    }
+
+    #[test]
+    fn raycast_does_not_treat_tiny_non_zero_axis_components_as_parallel() {
+        let bvh = Bvh3::build(vec![box_primitive(
+            20,
+            (1.0, 0.0, -1.0),
+            (2.0, 2.0e13, 1.0),
+        )]);
+        let ray = Ray3::new(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0e-13, 1.0, 0.0),
+            2.0e13,
+        )
+        .expect("tiny non-zero axis component should remain directional");
+
+        let hit = bvh
+            .raycast_first(&ray)
+            .expect("hit through tiny x component");
+        assert_eq!(hit.id, 20);
+        assert!(hit.distance > 9.0e12);
     }
 
     #[test]

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -240,19 +240,30 @@ impl Ray3 {
             );
         }
 
-        let length_squared =
-            direction.x * direction.x + direction.y * direction.y + direction.z * direction.z;
-        if length_squared <= RAY_EPSILON {
+        let max_component = direction
+            .x
+            .abs()
+            .max(direction.y.abs())
+            .max(direction.z.abs());
+        if max_component == 0.0 {
             return Err("Invalid ray: direction must be non-zero.".to_string());
         }
 
+        let scaled_direction = Vector3::new(
+            direction.x / max_component,
+            direction.y / max_component,
+            direction.z / max_component,
+        );
+        let length_squared = scaled_direction.x * scaled_direction.x
+            + scaled_direction.y * scaled_direction.y
+            + scaled_direction.z * scaled_direction.z;
         let inv_length = 1.0 / length_squared.sqrt();
         Ok(Self {
             origin,
             direction: Vector3::new(
-                direction.x * inv_length,
-                direction.y * inv_length,
-                direction.z * inv_length,
+                scaled_direction.x * inv_length,
+                scaled_direction.y * inv_length,
+                scaled_direction.z * inv_length,
             ),
             max_distance,
         })
@@ -792,6 +803,27 @@ mod tests {
         let hit = bvh.raycast_first(&ray).expect("nearest hit");
         assert_eq!(hit.id, 20);
         assert_eq!(hit.distance, 2.0);
+    }
+
+    #[test]
+    fn raycast_accepts_small_non_zero_direction_before_normalizing() {
+        let bvh = Bvh3::build(vec![box_primitive(20, (2.0, -1.0, -1.0), (3.0, 1.0, 1.0))]);
+        let ray = Ray3::new(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(1.0e-7, 0.0, 0.0),
+            100.0,
+        )
+        .expect("small non-zero direction should normalize");
+
+        let hit = bvh.raycast_first(&ray).expect("hit");
+        assert_eq!(hit.id, 20);
+        assert_eq!(hit.distance, 2.0);
+        assert!(Ray3::new(
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 0.0),
+            100.0,
+        )
+        .is_err());
     }
 
     #[test]

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -436,6 +436,16 @@ impl OGSpatialIndex {
         })
     }
 
+    #[wasm_bindgen(js_name = fromFlatArrays)]
+    pub fn from_flat_arrays(ids: Vec<u32>, bounds: Vec<f64>) -> Result<OGSpatialIndex, JsValue> {
+        let primitives =
+            primitives_from_flat_arrays(&ids, &bounds).map_err(|err| JsValue::from_str(&err))?;
+
+        Ok(Self {
+            bvh: Bvh3::build(primitives),
+        })
+    }
+
     #[wasm_bindgen(js_name = primitiveCount)]
     pub fn primitive_count(&self) -> usize {
         self.bvh.primitive_count()
@@ -461,10 +471,31 @@ impl OGSpatialIndex {
         serialize_ids(self.bvh.query_aabb(&bounds))
     }
 
+    #[wasm_bindgen(js_name = queryAabbIds)]
+    pub fn query_aabb_ids(
+        &self,
+        min_x: f64,
+        min_y: f64,
+        min_z: f64,
+        max_x: f64,
+        max_y: f64,
+        max_z: f64,
+    ) -> Result<Vec<u32>, JsValue> {
+        let bounds = Aabb3::from_coords(min_x, min_y, min_z, max_x, max_y, max_z)
+            .map_err(|err| JsValue::from_str(&err))?;
+        Ok(self.bvh.query_aabb(&bounds))
+    }
+
     #[wasm_bindgen(js_name = queryFrustum)]
     pub fn query_frustum(&self, planes_json: String) -> Result<String, JsValue> {
         let frustum = parse_frustum_json(&planes_json).map_err(|err| JsValue::from_str(&err))?;
         serialize_ids(self.bvh.query_frustum(&frustum))
+    }
+
+    #[wasm_bindgen(js_name = queryFrustumIds)]
+    pub fn query_frustum_ids(&self, planes_json: String) -> Result<Vec<u32>, JsValue> {
+        let frustum = parse_frustum_json(&planes_json).map_err(|err| JsValue::from_str(&err))?;
+        Ok(self.bvh.query_frustum(&frustum))
     }
 
     #[wasm_bindgen(js_name = raycastFirst)]
@@ -593,6 +624,33 @@ fn parse_frustum_json(planes_json: &str) -> Result<Frustum3, String> {
         .collect::<Result<Vec<_>, _>>()?;
 
     Frustum3::new(planes)
+}
+
+fn primitives_from_flat_arrays(ids: &[u32], bounds: &[f64]) -> Result<Vec<BvhPrimitive>, String> {
+    if bounds.len() != ids.len() * 6 {
+        return Err(format!(
+            "Invalid spatial index arrays: expected {} bounds values for {} ids, got {}.",
+            ids.len() * 6,
+            ids.len(),
+            bounds.len()
+        ));
+    }
+
+    ids.iter()
+        .enumerate()
+        .map(|(index, id)| {
+            let offset = index * 6;
+            Aabb3::from_coords(
+                bounds[offset],
+                bounds[offset + 1],
+                bounds[offset + 2],
+                bounds[offset + 3],
+                bounds[offset + 4],
+                bounds[offset + 5],
+            )
+            .map(|bounds| BvhPrimitive::new(*id, bounds))
+        })
+        .collect()
 }
 
 fn serialize_ids(ids: Vec<u32>) -> Result<String, JsValue> {
@@ -772,5 +830,24 @@ mod tests {
             .raycast_first(0.0, 2.5, 2.5, 1.0, 0.0, 0.0, 100.0)
             .expect("raycast hit");
         assert_eq!(ray_hit, r#"{"id":2,"distance":2.0}"#);
+    }
+
+    #[test]
+    fn wasm_spatial_index_builds_from_flat_arrays_and_returns_ids() {
+        let index = OGSpatialIndex::from_flat_arrays(
+            vec![11, 22, 33],
+            vec![
+                -2.0, 0.0, 0.0, -1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 6.0, 0.0, 0.0, 7.0,
+                1.0, 1.0,
+            ],
+        )
+        .expect("valid flat-array index");
+
+        let ids = index
+            .query_aabb_ids(0.0, 0.0, 0.0, 4.0, 4.0, 4.0)
+            .expect("typed aabb query ids");
+        assert_eq!(ids, vec![22]);
+
+        assert!(primitives_from_flat_arrays(&[1], &[0.0, 0.0, 0.0]).is_err());
     }
 }

--- a/main/opengeometry/src/spatial/bvh.rs
+++ b/main/opengeometry/src/spatial/bvh.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 const BVH_LEAF_SIZE: usize = 8;
-const RAY_EPSILON: f64 = 1.0e-12;
-
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct Aabb3 {
     pub min: Vector3,
@@ -196,8 +194,8 @@ impl Plane3 {
             return Err("Invalid frustum plane: constant must be finite.".to_string());
         }
 
-        let length_squared = normal.x * normal.x + normal.y * normal.y + normal.z * normal.z;
-        if length_squared <= RAY_EPSILON {
+        let max_component = normal.x.abs().max(normal.y.abs()).max(normal.z.abs());
+        if max_component == 0.0 {
             return Err("Invalid frustum plane: normal must be non-zero.".to_string());
         }
 
@@ -638,10 +636,14 @@ fn parse_frustum_json(planes_json: &str) -> Result<Frustum3, String> {
 }
 
 fn primitives_from_flat_arrays(ids: &[u32], bounds: &[f64]) -> Result<Vec<BvhPrimitive>, String> {
-    if bounds.len() != ids.len() * 6 {
+    let expected_bounds_len = ids
+        .len()
+        .checked_mul(6)
+        .ok_or_else(|| "Invalid spatial index arrays: id count is too large.".to_string())?;
+    if bounds.len() != expected_bounds_len {
         return Err(format!(
             "Invalid spatial index arrays: expected {} bounds values for {} ids, got {}.",
-            ids.len() * 6,
+            expected_bounds_len,
             ids.len(),
             bounds.len()
         ));
@@ -693,7 +695,7 @@ fn update_ray_interval(
     *t_min = (*t_min).max(near);
     *t_max = (*t_max).min(far);
 
-    (t_min <= t_max).then_some(())
+    (*t_min <= *t_max).then_some(())
 }
 
 fn validate_vector3(vector: Vector3, label: &str) -> Result<(), String> {
@@ -785,6 +787,20 @@ mod tests {
             sorted(bvh.query_frustum(&test_frustum())),
             vec![0, 1, 2, 3, 4, 5]
         );
+    }
+
+    #[test]
+    fn frustum_accepts_tiny_non_zero_plane_normals() {
+        let bvh = Bvh3::build(vec![
+            box_primitive(10, (-2.0, 0.0, 0.0), (-1.0, 1.0, 1.0)),
+            box_primitive(20, (1.0, 0.0, 0.0), (2.0, 1.0, 1.0)),
+        ]);
+        let frustum = Frustum3::new(vec![Plane3::new(Vector3::new(1.0e-13, 0.0, 0.0), 0.0)
+            .expect("tiny non-zero normal is valid")])
+        .expect("valid frustum");
+
+        assert_eq!(bvh.query_frustum(&frustum), vec![20]);
+        assert!(Plane3::new(Vector3::new(0.0, 0.0, 0.0), 0.0).is_err());
     }
 
     #[test]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "opengeometry",
-  "version": "2.0.9",
+  "version": "2.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengeometry",
-      "version": "2.0.9",
+      "version": "2.0.11",
       "license": "MPL-2.0",
       "dependencies": {
-        "tsc": "^2.0.4",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -3606,14 +3605,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tsc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
-      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
-      "bin": {
-        "tsc": "bin/tsc"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "cargo test --manifest-path main/opengeometry/Cargo.toml && cargo test --examples --manifest-path main/opengeometry/Cargo.toml",
     "lint": "eslint main/opengeometry-three/src/**/*.ts --fix",
     "lint:check": "eslint main/opengeometry-three/src/**/*.ts",
+    "benchmark:spatial-index": "node scripts/benchmark-spatial-index.mjs",
     "build-three": "rollup -c rollup.config.js",
     "build-example-three": "npm --prefix main/opengeometry-three run build-example-three",
     "build-core": "cd main/opengeometry && wasm-pack build --target web && cargo build --release",

--- a/scripts/benchmark-spatial-index.mjs
+++ b/scripts/benchmark-spatial-index.mjs
@@ -119,13 +119,18 @@ function percentile(values, p) {
   return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1))] ?? 0;
 }
 
-function measure(fn) {
+function measure(fn, options = {}) {
   const samples = [];
   let value;
   for (let index = 0; index < repeatCount; index += 1) {
     const startedAt = performance.now();
-    value = fn();
+    const nextValue = fn();
     samples.push(performance.now() - startedAt);
+    if (index === repeatCount - 1) {
+      value = nextValue;
+    } else {
+      options.dispose?.(nextValue);
+    }
   }
   return {
     value,
@@ -157,7 +162,9 @@ if (typeof OGSpatialIndex?.fromFlatArrays !== "function") {
 const { bounds, ids, items } = createSceneItems(itemCount);
 const queries = createQueries(queryCount);
 
-const build = measure(() => OGSpatialIndex.fromFlatArrays(ids, bounds));
+const build = measure(() => OGSpatialIndex.fromFlatArrays(ids, bounds), {
+  dispose: (value) => value.free?.(),
+});
 const index = build.value;
 
 const linearSamples = [];

--- a/scripts/benchmark-spatial-index.mjs
+++ b/scripts/benchmark-spatial-index.mjs
@@ -1,0 +1,207 @@
+/* eslint-env node */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, "..");
+const pkgDir = path.join(rootDir, "main", "opengeometry", "pkg");
+const openGeometryJsPath = path.join(pkgDir, "opengeometry.js");
+const openGeometryWasmPath = path.join(pkgDir, "opengeometry_bg.wasm");
+
+const readOption = (name, fallback) => {
+  const prefix = `--${name}=`;
+  const value = process.argv.find((arg) => arg.startsWith(prefix));
+  return value ? value.slice(prefix.length) : fallback;
+};
+
+const readIntegerOption = (name, fallback) => {
+  const value = Number(readOption(name, fallback));
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid --${name}: expected a positive integer.`);
+  }
+  return value;
+};
+
+const itemCount = readIntegerOption("items", "50000");
+const queryCount = readIntegerOption("queries", "100");
+const repeatCount = readIntegerOption("repeats", "3");
+
+function createPrng(seed) {
+  let state = seed >>> 0;
+  return () => {
+    state += 0x6d2b79f5;
+    let value = state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function createSceneItems(count) {
+  const random = createPrng(0x0aabb777 ^ count);
+  const ids = new Uint32Array(count);
+  const bounds = new Float64Array(count * 6);
+  const items = new Array(count);
+
+  for (let index = 0; index < count; index += 1) {
+    const x = (random() - 0.5) * 1000;
+    const y = (random() - 0.5) * 140;
+    const z = (random() - 0.5) * 1000;
+    const width = 0.5 + random() * 8;
+    const height = 0.5 + random() * 6;
+    const depth = 0.5 + random() * 8;
+    const minX = x - width * 0.5;
+    const minY = y - height * 0.5;
+    const minZ = z - depth * 0.5;
+    const maxX = x + width * 0.5;
+    const maxY = y + height * 0.5;
+    const maxZ = z + depth * 0.5;
+    const offset = index * 6;
+
+    ids[index] = index + 1;
+    bounds[offset] = minX;
+    bounds[offset + 1] = minY;
+    bounds[offset + 2] = minZ;
+    bounds[offset + 3] = maxX;
+    bounds[offset + 4] = maxY;
+    bounds[offset + 5] = maxZ;
+    items[index] = { id: index + 1, minX, minY, minZ, maxX, maxY, maxZ };
+  }
+
+  return { bounds, ids, items };
+}
+
+function createQueries(count) {
+  const random = createPrng(0x5eed1234 ^ count);
+  const queries = new Array(count);
+
+  for (let index = 0; index < count; index += 1) {
+    const x = (random() - 0.5) * 1000;
+    const y = (random() - 0.5) * 140;
+    const z = (random() - 0.5) * 1000;
+    const radius = 20 + random() * 120;
+    queries[index] = {
+      minX: x - radius,
+      minY: y - radius * 0.5,
+      minZ: z - radius,
+      maxX: x + radius,
+      maxY: y + radius * 0.5,
+      maxZ: z + radius,
+    };
+  }
+
+  return queries;
+}
+
+function intersects(item, query) {
+  return item.minX <= query.maxX
+    && item.maxX >= query.minX
+    && item.minY <= query.maxY
+    && item.maxY >= query.minY
+    && item.minZ <= query.maxZ
+    && item.maxZ >= query.minZ;
+}
+
+function linearQuery(items, query) {
+  const hits = [];
+  for (const item of items) {
+    if (intersects(item, query)) {
+      hits.push(item.id);
+    }
+  }
+  return hits;
+}
+
+function percentile(values, p) {
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1))] ?? 0;
+}
+
+function measure(fn) {
+  const samples = [];
+  let value;
+  for (let index = 0; index < repeatCount; index += 1) {
+    const startedAt = performance.now();
+    value = fn();
+    samples.push(performance.now() - startedAt);
+  }
+  return {
+    value,
+    minMs: Math.min(...samples),
+    p50Ms: percentile(samples, 0.5),
+    p95Ms: percentile(samples, 0.95),
+  };
+}
+
+function sameIds(left, right) {
+  if (left.length !== right.length) return false;
+  const sortedLeft = [...left].sort((a, b) => a - b);
+  const sortedRight = [...right].sort((a, b) => a - b);
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+if (!existsSync(openGeometryJsPath) || !existsSync(openGeometryWasmPath)) {
+  throw new Error("OpenGeometry WASM package is missing. Run `npm run build-core` first.");
+}
+
+const openGeometry = await import(pathToFileURL(openGeometryJsPath).href);
+await openGeometry.default({ module_or_path: readFileSync(openGeometryWasmPath) });
+
+const { OGSpatialIndex } = openGeometry;
+if (typeof OGSpatialIndex?.fromFlatArrays !== "function") {
+  throw new Error("OGSpatialIndex.fromFlatArrays is not available in the WASM package.");
+}
+
+const { bounds, ids, items } = createSceneItems(itemCount);
+const queries = createQueries(queryCount);
+
+const build = measure(() => OGSpatialIndex.fromFlatArrays(ids, bounds));
+const index = build.value;
+
+const linearSamples = [];
+const wasmSamples = [];
+let totalHits = 0;
+
+for (const query of queries) {
+  const linear = measure(() => linearQuery(items, query));
+  const wasm = measure(() => index.queryAabbIds(
+    query.minX,
+    query.minY,
+    query.minZ,
+    query.maxX,
+    query.maxY,
+    query.maxZ,
+  ));
+
+  if (!sameIds(linear.value, wasm.value)) {
+    throw new Error(
+      `Query mismatch: linear=${linear.value.length}, wasm=${wasm.value.length}.`
+    );
+  }
+
+  totalHits += wasm.value.length;
+  linearSamples.push(linear.p50Ms);
+  wasmSamples.push(wasm.p50Ms);
+}
+
+const linearP50Ms = percentile(linearSamples, 0.5);
+const wasmP50Ms = percentile(wasmSamples, 0.5);
+const nodeCount = index.nodeCount();
+
+index.free?.();
+
+console.log(JSON.stringify({
+  benchmark: "spatial-index",
+  itemCount,
+  queryCount,
+  repeatCount,
+  primitiveCount: ids.length,
+  nodeCount,
+  totalHits,
+  buildP50Ms: build.p50Ms,
+  linearQueryP50Ms: linearP50Ms,
+  wasmQueryP50Ms: wasmP50Ms,
+  querySpeedup: linearP50Ms > 0 ? linearP50Ms / Math.max(wasmP50Ms, 0.0001) : 0,
+}, null, 2));


### PR DESCRIPTION
## Summary

Add a lightweight WASM-backed AABB BVH spatial index (OGSpatialIndex) to the OpenGeometry kernel. This enables broad-phase scene queries — AABB intersection, frustum culling, and ray-vs-bounds — entirely inside the WASM runtime, avoiding JavaScript-side linear scans for large scenes.

## What's Included

### Rust Kernel (main/opengeometry/src/spatial/bvh.rs)
- Pure-Rust BVH over axis-aligned bounding boxes, zero new dependencies
- **AABB query**: returns IDs whose bounds intersect a query box
- **Frustum query**: returns IDs whose bounds intersect a set of frustum planes
- **Raycast**: returns the nearest intersected bounding box (broad-phase only)
- Input validation: rejects non-finite coords, inverted min/max, mismatched array lengths, zero normals, bad rays
- Focused unit tests covering construction, AABB queries, frustum queries, ray queries, flat-array construction, and selected invalid inputs

### JS/TS Bindings (main/opengeometry-three/index.ts)
- Re-export OGSpatialIndex from the public API
- Two construction paths:
  - new OGSpatialIndex(jsonString) — convenient for small payloads
  - OGSpatialIndex.fromFlatArrays(Uint32Array, Float64Array) — JSON-free path for larger scene payloads
- Typed-array result methods (queryAabbIds, queryFrustumIds) alongside JSON methods

### Benchmark (scripts/benchmark-spatial-index.mjs)
- Deterministic PRNG for reproducible scenes (default: 50K items, 100 queries)
- Correctness validation: every WASM query result is cross-checked against a linear scan
- Reports build time, query p50, and speedup factor as structured JSON

### Documentation
- **API Reference** (docs/api/core/spatial-index.mdx): full method docs with examples, param descriptions, and warnings
- **Concept Page** (docs/concepts/spatial-index.mdx): data model, runtime flow, kernel placement rationale, and limits
- Architecture diagram and navigation updated

## Design Decisions

- **Kernel-level, not application-level**: The spatial index lives in the Rust core because AABB queries are geometry-adjacent and useful across scene export, viewport culling, picking, and downstream AEC/BIM tools.
- **Immutable after construction**: Keeps the BVH simple and predictable. Applications rebuild when bounds change.
- **Broad-phase only**: This is not a triangle-level mesh BVH. Applications should use query results as a candidate set for their own narrow-phase tests.

## Testing

- `cargo test --manifest-path main/opengeometry/Cargo.toml spatial::bvh` — all spatial tests pass
- `npm run build` — WASM package builds successfully
- `node scripts/benchmark-spatial-index.mjs --items=5000 --queries=20 --repeats=2` — correctness validated against linear scan baseline