### PR TITLE
Add offsetRingVariable: per-edge ring inset for setback envelopes

### DIFF
--- a/main/opengeometry-three/examples-vite/index.html
+++ b/main/opengeometry-three/examples-vite/index.html
@@ -597,6 +597,21 @@
           </article>
           <article class="og-example-card">
             <div class="og-card-top">
+              <h3 class="og-card-title">Variable Ring Offset</h3>
+            </div>
+            <p class="og-card-desc">
+              Per-edge ring inset (setback envelope) with live front/side/rear distances and a
+              splitting dumbbell parcel.
+            </p>
+            <div class="og-tag-row">
+              <span class="og-tag">Ring</span>
+              <span class="og-tag">Offset</span>
+              <span class="og-tag">Setback</span>
+            </div>
+            <a class="og-open" href="./operations/offset-ring-variable.html">Open example</a>
+          </article>
+          <article class="og-example-card">
+            <div class="og-card-top">
               <h3 class="og-card-title">General Extrude</h3>
             </div>
             <p class="og-card-desc">Directional extrude with arbitrary direction and extent type.</p>

--- a/main/opengeometry-three/examples-vite/operations/offset-ring-variable.html
+++ b/main/opengeometry-three/examples-vite/operations/offset-ring-variable.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>OpenGeometry Variable Ring Offset Example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="description"
+      content="Per-edge ring inset (setback envelope) example for Three.js."
+    />
+    <meta name="author" content="OpenGeometry" />
+  </head>
+  <body class="og-example-page">
+    <div class="og-badge-title-card">
+      <a href="../index.html" class="og-badge-title-link">Back</a>
+      <span class="og-badge-title">Variable Ring Offset</span>
+    </div>
+
+    <aside class="og-controls">
+      <h3>Setback Envelope</h3>
+      <p class="og-control-summary">
+        The dark ring is the parcel. The green ring(s) are the buildable envelope from
+        <code>offsetRingVariable</code> — one inset distance per lot-line edge. Deepen the
+        setbacks on the dumbbell parcel and the envelope splits in two.
+      </p>
+
+      <label class="og-control-row" data-control="front">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Front Setback (m)</span>
+          <code class="og-control-value" data-value>6</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0" max="12" step="0.5" value="6" />
+          <input data-number type="number" min="0" max="12" step="0.5" value="6" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="side">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Side Setback (m)</span>
+          <code class="og-control-value" data-value>1.5</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0" max="9" step="0.5" value="1.5" />
+          <input data-number type="number" min="0" max="9" step="0.5" value="1.5" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="rear">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Rear Setback (m)</span>
+          <code class="og-control-value" data-value>3</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0" max="12" step="0.5" value="3" />
+          <input data-number type="number" min="0" max="12" step="0.5" value="3" />
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="dumbbell">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Dumbbell Parcel</span>
+        </div>
+        <div class="og-control-bool">
+          <input data-toggle type="checkbox" class="og-toggle" aria-label="Dumbbell Parcel" />
+          <span class="og-control-bool-state" data-state>Disabled</span>
+        </div>
+      </label>
+
+      <label class="og-control-row" data-control="waist">
+        <div class="og-control-header">
+          <span class="og-control-label-chip">Dumbbell Inset (m)</span>
+          <code class="og-control-value" data-value>3</code>
+        </div>
+        <div class="og-control-range">
+          <input data-range type="range" min="0" max="6" step="0.25" value="3" />
+          <input data-number type="number" min="0" max="6" step="0.25" value="3" />
+        </div>
+      </label>
+    </aside>
+
+    <div id="app"></div>
+
+    <script type="module">
+      import "../src/styles/theme.css";
+      import * as THREE from "three";
+      import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
+      import Stats from "three/examples/jsm/libs/stats.module.js";
+      import wasmUrl from "../../../opengeometry/pkg/opengeometry_bg.wasm?url";
+      import { OpenGeometry, Polyline, Vector3, offsetRingVariable } from "opengeometry";
+
+      const app = document.getElementById("app");
+      if (!app) {
+        throw new Error("Missing #app container");
+      }
+
+      // A 20 × 30 m parcel: edge 0 = front (z = 0), edges 1/3 = sides, edge 2 = rear.
+      const RECT_PARCEL = [0, 0, 0, 20, 0, 0, 20, 0, 30, 0, 0, 30];
+      // Two 20 × 14 m lobes joined by a 4 m-wide waist corridor.
+      const DUMBBELL_PARCEL = [
+        0, 0, 0, 20, 0, 0, 20, 0, 14, 12, 0, 14, 12, 0, 26, 20, 0, 26,
+        20, 0, 40, 0, 0, 40, 0, 0, 26, 8, 0, 26, 8, 0, 14, 0, 0, 14,
+      ];
+      const SCALE = 0.2; // metres → scene units
+
+      const config = {
+        front: 6,
+        side: 1.5,
+        rear: 3,
+        dumbbell: false,
+        waist: 3,
+      };
+
+      let scene = null;
+      let parcelOutline = null;
+      let envelopeOutlines = [];
+
+      function formatNumber(value) {
+        return Number(value).toFixed(2).replace(/\.?0+$/, "");
+      }
+
+      function mountStats() {
+        const stats = new Stats();
+        stats.showPanel(0);
+        stats.dom.style.position = "fixed";
+        stats.dom.style.left = "12px";
+        stats.dom.style.bottom = "12px";
+        stats.dom.style.top = "auto";
+        stats.dom.style.zIndex = "1000";
+        document.body.appendChild(stats.dom);
+        return stats;
+      }
+
+      function attachNumberControl(name, onChange) {
+        const row = document.querySelector(`[data-control="${name}"]`);
+        const range = row?.querySelector("[data-range]");
+        const number = row?.querySelector("[data-number]");
+        const value = row?.querySelector("[data-value]");
+        if (!row || !range || !number || !value) {
+          throw new Error(`Missing number control: ${name}`);
+        }
+        const commit = (nextValue) => {
+          const parsed = Number(nextValue);
+          if (!Number.isFinite(parsed)) {
+            return;
+          }
+          range.value = String(parsed);
+          number.value = String(parsed);
+          value.textContent = formatNumber(parsed);
+          onChange(parsed);
+        };
+        range.addEventListener("input", () => commit(range.value));
+        number.addEventListener("input", () => commit(number.value));
+        commit(range.value);
+      }
+
+      function attachBooleanControl(name, onChange) {
+        const row = document.querySelector(`[data-control="${name}"]`);
+        const toggle = row?.querySelector("[data-toggle]");
+        const state = row?.querySelector("[data-state]");
+        if (!row || !toggle || !state) {
+          throw new Error(`Missing boolean control: ${name}`);
+        }
+        const commit = (checked) => {
+          toggle.checked = checked;
+          state.textContent = checked ? "Enabled" : "Disabled";
+          onChange(checked);
+        };
+        toggle.addEventListener("change", () => commit(toggle.checked));
+        commit(toggle.checked);
+      }
+
+      function ringToScenePoints(flat) {
+        const points = [];
+        for (let i = 0; i < flat.length; i += 3) {
+          points.push(new Vector3(flat[i] * SCALE, flat[i + 1] * SCALE, flat[i + 2] * SCALE));
+        }
+        if (points.length > 0) {
+          points.push(new Vector3(flat[0] * SCALE, flat[1] * SCALE, flat[2] * SCALE));
+        }
+        return points;
+      }
+
+      function regionToScenePoints(region) {
+        const points = region.outer.map(
+          (p) => new Vector3(p.x * SCALE, p.y * SCALE, p.z * SCALE)
+        );
+        if (region.outer.length > 0) {
+          const first = region.outer[0];
+          points.push(new Vector3(first.x * SCALE, first.y * SCALE, first.z * SCALE));
+        }
+        return points;
+      }
+
+      function currentParcelAndDistances() {
+        if (config.dumbbell) {
+          return {
+            parcel: DUMBBELL_PARCEL,
+            distances: new Array(12).fill(config.waist),
+          };
+        }
+        // Rect edge order: front (z=0), side (x=20), rear (z=30), side (x=0).
+        return {
+          parcel: RECT_PARCEL,
+          distances: [config.front, config.side, config.rear, config.side],
+        };
+      }
+
+      function updateEnvelope() {
+        if (!scene || !parcelOutline) {
+          return;
+        }
+        const { parcel, distances } = currentParcelAndDistances();
+        parcelOutline.setConfig({ points: ringToScenePoints(parcel), color: 0x1f2937 });
+
+        for (const outline of envelopeOutlines) {
+          scene.remove(outline);
+        }
+        envelopeOutlines = [];
+
+        let regions = [];
+        try {
+          regions = offsetRingVariable(parcel, distances);
+        } catch (error) {
+          console.error("[offset-ring-variable]", error);
+          return;
+        }
+
+        for (const region of regions) {
+          const outline = new Polyline({
+            points: regionToScenePoints(region),
+            color: regions.length > 1 ? 0xdc2626 : 0x16a34a,
+          });
+          envelopeOutlines.push(outline);
+          scene.add(outline);
+        }
+
+        console.groupCollapsed("[offset-ring-variable] updated");
+        console.log("Config", { ...config });
+        console.log(
+          `Regions: ${regions.length}`,
+          regions.map((region) => `${region.outer.length} verts`)
+        );
+        console.groupEnd();
+      }
+
+      async function main() {
+        scene = new THREE.Scene();
+        scene.background = new THREE.Color(0xeef2ff);
+
+        const camera = new THREE.PerspectiveCamera(
+          55,
+          window.innerWidth / window.innerHeight,
+          0.1,
+          100
+        );
+        camera.position.set(8.5, 7.5, 10.2);
+
+        const renderer = new THREE.WebGLRenderer({ antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio);
+        renderer.setSize(window.innerWidth, window.innerHeight);
+        app.replaceChildren(renderer.domElement);
+
+        const stats = mountStats();
+        const controls = new OrbitControls(camera, renderer.domElement);
+        controls.enableDamping = true;
+        controls.target.set(2, 0, 3);
+        controls.update();
+
+        scene.add(new THREE.GridHelper(24, 24, 0x4460ff, 0xd5ddff));
+        scene.add(new THREE.AmbientLight(0xffffff, 0.82));
+
+        const light = new THREE.DirectionalLight(0xffffff, 1.1);
+        light.position.set(6, 8, 4);
+        scene.add(light);
+
+        await OpenGeometry.create({ wasmURL: wasmUrl });
+
+        parcelOutline = new Polyline({
+          points: ringToScenePoints(RECT_PARCEL),
+          color: 0x1f2937,
+        });
+        scene.add(parcelOutline);
+
+        attachNumberControl("front", (value) => {
+          config.front = value;
+          updateEnvelope();
+        });
+        attachNumberControl("side", (value) => {
+          config.side = value;
+          updateEnvelope();
+        });
+        attachNumberControl("rear", (value) => {
+          config.rear = value;
+          updateEnvelope();
+        });
+        attachNumberControl("waist", (value) => {
+          config.waist = value;
+          updateEnvelope();
+        });
+        attachBooleanControl("dumbbell", (value) => {
+          config.dumbbell = value;
+          updateEnvelope();
+        });
+
+        updateEnvelope();
+
+        renderer.setAnimationLoop(() => {
+          stats.update();
+          controls.update();
+          renderer.render(scene, camera);
+        });
+
+        window.addEventListener("resize", () => {
+          camera.aspect = window.innerWidth / window.innerHeight;
+          camera.updateProjectionMatrix();
+          renderer.setSize(window.innerWidth, window.innerHeight);
+        });
+      }
+
+      main();
+    </script>
+  </body>
+</html>

--- a/main/opengeometry-three/src/examples/index.ts
+++ b/main/opengeometry-three/src/examples/index.ts
@@ -5,6 +5,7 @@ export * from './primitives';
 export * from './shapes';
 export * from './sweep';
 export * from './offset';
+export * from './offset-ring-variable';
 export * from './wall-from-offsets';
 export * from './booleans';
 export * from './editor-modes';

--- a/main/opengeometry-three/src/examples/offset-ring-variable.ts
+++ b/main/opengeometry-three/src/examples/offset-ring-variable.ts
@@ -1,0 +1,71 @@
+import * as THREE from "three";
+import { Vector3 } from "../../../opengeometry/pkg/opengeometry";
+import { Polyline } from "../primitives/polyline";
+import { offsetRingVariable } from "../operations/offset-regions";
+
+/** Close a kernel ring for Polyline rendering (repeat the first point). */
+function closedRingPoints(ring: { x: number; y: number; z: number }[]): Vector3[] {
+  const points = ring.map((point) => new Vector3(point.x, point.y, point.z));
+  if (points.length > 0) {
+    const first = ring[0];
+    points.push(new Vector3(first.x, first.y, first.z));
+  }
+  return points;
+}
+
+/**
+ * Variable (per-edge) ring inset: a rectangular "parcel" inset by front 6 /
+ * side 1.5 / rear 3 setbacks, and a waisted (dumbbell) parcel whose uniform
+ * 3 m inset SPLITS into two disjoint buildable envelopes — the case a uniform
+ * offset cannot express.
+ */
+export function createOffsetRingVariableExample(scene: THREE.Scene) {
+  const scale = 0.2; // metres → scene units, keeps both parcels in frame
+
+  const parcel = [0, 0, 0, 20, 0, 0, 20, 0, 30, 0, 0, 30].map((v) => v * scale);
+  const parcelSetbacks = [6, 1.5, 3, 1.5].map((v) => v * scale);
+
+  const dumbbell = [
+    0, 0, 0, 20, 0, 0, 20, 0, 14, 12, 0, 14, 12, 0, 26, 20, 0, 26, 20, 0, 40, 0, 0, 40, 0, 0, 26,
+    8, 0, 26, 8, 0, 14, 0, 0, 14,
+  ].map((v, index) => (index % 3 === 0 ? v * scale + 6 : v * scale)); // shifted +x
+  const dumbbellSetbacks = new Array(12).fill(3 * scale);
+
+  const parcelOutline = new Polyline({
+    points: closedRingPoints(
+      Array.from({ length: parcel.length / 3 }, (_, i) => ({
+        x: parcel[i * 3],
+        y: parcel[i * 3 + 1],
+        z: parcel[i * 3 + 2],
+      })),
+    ),
+    color: 0x1f2937,
+  });
+  scene.add(parcelOutline);
+
+  const dumbbellOutline = new Polyline({
+    points: closedRingPoints(
+      Array.from({ length: dumbbell.length / 3 }, (_, i) => ({
+        x: dumbbell[i * 3],
+        y: dumbbell[i * 3 + 1],
+        z: dumbbell[i * 3 + 2],
+      })),
+    ),
+    color: 0x1f2937,
+  });
+  scene.add(dumbbellOutline);
+
+  const envelopes: Polyline[] = [];
+  for (const region of offsetRingVariable(parcel, parcelSetbacks)) {
+    const envelope = new Polyline({ points: closedRingPoints(region.outer), color: 0x16a34a });
+    envelopes.push(envelope);
+    scene.add(envelope);
+  }
+  for (const region of offsetRingVariable(dumbbell, dumbbellSetbacks)) {
+    const envelope = new Polyline({ points: closedRingPoints(region.outer), color: 0xdc2626 });
+    envelopes.push(envelope);
+    scene.add(envelope);
+  }
+
+  return { parcelOutline, dumbbellOutline, envelopes };
+}

--- a/main/opengeometry-three/src/operations/offset-regions.ts
+++ b/main/opengeometry-three/src/operations/offset-regions.ts
@@ -57,6 +57,50 @@ export function offsetPolylineRegions(
   return JSON.parse(result.regionsSerialized);
 }
 
+type KernelOffsetRingVariable = (
+  ringFlat: Float64Array,
+  distances: Float64Array,
+) => KernelOffsetRegionsResult;
+
+/**
+ * Inset a CLOSED ring inward with one distance per edge (edge i =
+ * `ring[i] → ring[i+1]`; an explicit closing duplicate point is accepted and
+ * stripped, the distance count stays one per unique edge). Built for setback
+ * envelopes: the result is the CLEARANCE-EXACT buildable region — the ring's
+ * interior minus every point within `distances[i]` of edge i's SEGMENT, so
+ * distant lot lines are honoured across notches and corners where distances
+ * differ become circumscribed clearance arcs (conservative). There is no
+ * `miterLimit` parameter, deliberately: miters and bevels only approximate the
+ * clearance arc, and a bevel would claim points inside the required distance.
+ *
+ * Returns CW-outer / CCW-hole regions (canonical start vertex), possibly
+ * SEVERAL when a deep inset splits a waisted ring into disjoint lobes, and an
+ * EMPTY array when the inset collapses or the input ring is degenerate
+ * (< 3 unique points, zero area, self-intersecting). THROWS on malformed
+ * arguments: a distance count that does not match the edge count, or a
+ * negative / non-finite distance — those are caller bugs, not geometry.
+ *
+ * @param ring closed ring points as `[x,y,z, …]` (Y is carried through).
+ * @param distances inward inset distance per edge, metres, each >= 0
+ *                  (0 = the edge stays in place, e.g. lot-line construction).
+ */
+export function offsetRingVariable(
+  ring: number[] | Float64Array,
+  distances: number[] | Float64Array,
+): OffsetRegion[] {
+  const buildExport = (OGKernel as Record<string, unknown>).offsetRingVariable;
+  if (typeof buildExport !== "function") {
+    throw new Error(
+      "offsetRingVariable is not available in the loaded wasm package. It requires opengeometry >= 2.0.12 — rebuild or upgrade the opengeometry wasm bindings.",
+    );
+  }
+  const flatRing = ring instanceof Float64Array ? ring : new Float64Array(ring);
+  const flatDistances =
+    distances instanceof Float64Array ? distances : new Float64Array(distances);
+  const result = (buildExport as KernelOffsetRingVariable)(flatRing, flatDistances);
+  return JSON.parse(result.regionsSerialized);
+}
+
 /** One polyline in an offset group: centreline `[x,y,z, …]`, stroke width, closed flag. */
 export interface OffsetPolyline {
   centreline: number[];

--- a/main/opengeometry/Cargo.toml
+++ b/main/opengeometry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opengeometry"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["Vishwajeet Mane <manevishwajeet1@gmail.com>"]
 description = "Graphics Kernel for Next Gen"
 license = "MIT/Apache-2.0"

--- a/main/opengeometry/src/export/ifc.rs
+++ b/main/opengeometry/src/export/ifc.rs
@@ -12,7 +12,9 @@ use super::part21::{sanitize_string_literal, Part21Writer};
 
 const IFC_LENGTH_EPSILON: f64 = 1.0e-12;
 const IFC_CLASS_PROXY: &str = "IFCBUILDINGELEMENTPROXY";
-const IFC_ALLOWED_CLASSES: [&str; 12] = [
+const IFC_CLASS_SPACE: &str = "IFCSPACE";
+const IFC_CLASS_SITE: &str = "IFCSITE";
+const IFC_ALLOWED_CLASSES: [&str; 14] = [
     IFC_CLASS_PROXY,
     "IFCWALL",
     "IFCSLAB",
@@ -25,6 +27,8 @@ const IFC_ALLOWED_CLASSES: [&str; 12] = [
     "IFCSTAIR",
     "IFCRAILING",
     "IFCFOOTING",
+    IFC_CLASS_SPACE,
+    IFC_CLASS_SITE,
 ];
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -58,6 +62,17 @@ impl IfcSchemaVersion {
     }
 }
 
+/// A typed IfcPropertySingleValue payload. `#[serde(untagged)]` keeps the
+/// config JSON natural (`true` / `4500` / `"office"`) and remains backward
+/// compatible with the previous string-only property sets.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum IfcPropertyValue {
+    Bool(bool),
+    Number(f64),
+    Text(String),
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct IfcEntitySemantics {
     pub ifc_class: Option<String>,
@@ -66,7 +81,7 @@ pub struct IfcEntitySemantics {
     pub object_type: Option<String>,
     pub tag: Option<String>,
     #[serde(default)]
-    pub property_sets: HashMap<String, HashMap<String, String>>,
+    pub property_sets: HashMap<String, HashMap<String, IfcPropertyValue>>,
     #[serde(default)]
     pub quantity_sets: HashMap<String, HashMap<String, f64>>,
 }
@@ -92,6 +107,11 @@ pub struct IfcExportConfig {
     /// tessellation when a brep has no analytic geometry.
     #[serde(default = "default_true_ifc")]
     pub analytic_surfaces: bool,
+    /// Convert source Y-up geometry (Three.js convention) to IFC's Z-up
+    /// world by mapping `(x, y, z) -> (x, -z, y)` once, before any
+    /// emission. Default on, since kernel BReps are authored Y-up.
+    #[serde(default = "default_true_ifc")]
+    pub up_axis_conversion: bool,
 }
 
 fn default_true_ifc() -> bool {
@@ -113,8 +133,42 @@ impl Default for IfcExportConfig {
             semantics: None,
             length_unit: crate::units::LengthUnit::default(),
             analytic_surfaces: true,
+            up_axis_conversion: true,
         }
     }
+}
+
+/// Map a single source Y-up coordinate/direction to IFC Z-up:
+/// `(x, y, z) -> (x, -z, y)`. A proper rotation (+90° about X,
+/// determinant +1) so handedness is preserved and nothing mirrors.
+fn to_z_up(v: Vector3) -> Vector3 {
+    Vector3::new(v.x, -v.z, v.y)
+}
+
+/// Return a Z-up copy of `brep`, transforming vertices, analytic edge
+/// curves and face surfaces consistently, then recomputing normals.
+/// Applied exactly once at export entry so the rest of the pipeline is
+/// untouched and double-application is impossible.
+fn brep_to_z_up(brep: &Brep) -> Brep {
+    let mut converted = brep.clone();
+    for vertex in &mut converted.vertices {
+        vertex.position = to_z_up(vertex.position);
+    }
+    for edge in &mut converted.edges {
+        if let Some(curve) = &edge.curve {
+            // scale = 1.0: the conversion carries no scale (radii unchanged).
+            edge.curve = Some(curve.transformed_with(&to_z_up, 1.0));
+        }
+    }
+    for face in &mut converted.faces {
+        if let Some(surface) = &face.surface {
+            face.surface = Some(surface.transformed_with(&to_z_up, 1.0));
+        }
+    }
+    if !converted.faces.is_empty() {
+        converted.recompute_face_normals();
+    }
+    converted
 }
 
 /// IFC SI prefix token (e.g. `.MILLI.`) for the length unit, or `$` for the
@@ -287,6 +341,28 @@ fn export_owned_entities_to_ifc_text<'a>(
         return Err(IfcExportError::EmptyInput);
     }
 
+    // Y-up -> Z-up once, up front: convert each BREP and re-bind the
+    // working entities to the converted geometry. Everything downstream
+    // (analytic surfaces, tessellation, placements) then operates on
+    // Z-up data unchanged.
+    let converted_breps: Vec<Brep>;
+    let converted_entities: Vec<IfcOwnedEntity<'_>>;
+    let entities: &[IfcOwnedEntity<'_>] = if config.up_axis_conversion {
+        converted_breps = entities.iter().map(|e| brep_to_z_up(e.brep)).collect();
+        converted_entities = entities
+            .iter()
+            .zip(converted_breps.iter())
+            .map(|(e, brep)| IfcOwnedEntity {
+                entity_id: e.entity_id.clone(),
+                kind: e.kind.clone(),
+                brep,
+            })
+            .collect();
+        &converted_entities
+    } else {
+        entities
+    };
+
     let mut report = IfcExportReport {
         input_breps: entities.len(),
         ..IfcExportReport::default()
@@ -409,6 +485,8 @@ fn export_owned_entities_to_ifc_text<'a>(
     ));
 
     let mut element_ids = Vec::new();
+    let mut space_ids = Vec::new();
+    let mut site_ids = Vec::new();
 
     for entity in entities {
         let brep = entity.brep;
@@ -523,24 +601,63 @@ fn export_owned_entities_to_ifc_text<'a>(
             .and_then(|sem| sem.tag.clone())
             .unwrap_or_else(|| entity.entity_id.clone());
 
-        let element_expr = format!(
-            "{}('{}',$,'{}',{},'{}',{},{},'{}',.NOTDEFINED.)",
-            class_name,
-            ifc_guid(&format!("element-{}", entity.entity_id)),
-            sanitize_string_literal(&name),
-            if description.is_empty() {
-                "$".to_string()
-            } else {
-                format!("'{}'", sanitize_string_literal(&description))
-            },
-            sanitize_string_literal(&object_type),
-            Part21Writer::reference(placement),
-            Part21Writer::reference(definition_shape),
-            sanitize_string_literal(&tag)
-        );
+        let guid = ifc_guid(&format!("element-{}", entity.entity_id));
+        let name_literal = sanitize_string_literal(&name);
+        let description_expr = if description.is_empty() {
+            "$".to_string()
+        } else {
+            format!("'{}'", sanitize_string_literal(&description))
+        };
+        let object_type_literal = sanitize_string_literal(&object_type);
+        let placement_ref = Part21Writer::reference(placement);
+        let shape_ref = Part21Writer::reference(definition_shape);
+        let tag_literal = sanitize_string_literal(&tag);
+
+        // IfcSpace and IfcSite are spatial elements with their own attribute
+        // signatures (LongName + CompositionType instead of Tag); everything
+        // else uses the shared building-element signature.
+        let element_expr = match class_name {
+            IFC_CLASS_SPACE => format!(
+                "IFCSPACE('{}',$,'{}',{},'{}',{},{},'{}',.ELEMENT.,.NOTDEFINED.,$)",
+                guid,
+                name_literal,
+                description_expr,
+                object_type_literal,
+                placement_ref,
+                shape_ref,
+                tag_literal
+            ),
+            IFC_CLASS_SITE => format!(
+                "IFCSITE('{}',$,'{}',{},'{}',{},{},'{}',.ELEMENT.,$,$,$,$,$)",
+                guid,
+                name_literal,
+                description_expr,
+                object_type_literal,
+                placement_ref,
+                shape_ref,
+                tag_literal
+            ),
+            _ => format!(
+                "{}('{}',$,'{}',{},'{}',{},{},'{}',.NOTDEFINED.)",
+                class_name,
+                guid,
+                name_literal,
+                description_expr,
+                object_type_literal,
+                placement_ref,
+                shape_ref,
+                tag_literal
+            ),
+        };
 
         let element_id = writer.add_entity(element_expr);
-        element_ids.push(element_id);
+        // Spatial elements may not ride IfcRelContainedInSpatialStructure:
+        // spaces AGGREGATE under the storey, extra sites under the project.
+        match class_name {
+            IFC_CLASS_SPACE => space_ids.push(element_id),
+            IFC_CLASS_SITE => site_ids.push(element_id),
+            _ => element_ids.push(element_id),
+        }
 
         if let Some(semantics) = semantics {
             write_property_sets(
@@ -562,18 +679,36 @@ fn export_owned_entities_to_ifc_text<'a>(
         report.exported_elements += 1;
     }
 
-    if element_ids.is_empty() {
+    if element_ids.is_empty() && space_ids.is_empty() && site_ids.is_empty() {
         return Err(IfcExportError::MeshGeneration(
             "No elements were exported from the provided BREP inputs".to_string(),
         ));
     }
 
-    writer.add_entity(format!(
-        "IFCRELCONTAINEDINSPATIALSTRUCTURE('{}',$,'ContainedInStorey',$,({}),{})",
-        ifc_guid("rel-contained-storey"),
-        join_refs(&element_ids),
-        Part21Writer::reference(storey)
-    ));
+    if !element_ids.is_empty() {
+        writer.add_entity(format!(
+            "IFCRELCONTAINEDINSPATIALSTRUCTURE('{}',$,'ContainedInStorey',$,({}),{})",
+            ifc_guid("rel-contained-storey"),
+            join_refs(&element_ids),
+            Part21Writer::reference(storey)
+        ));
+    }
+    if !space_ids.is_empty() {
+        writer.add_entity(format!(
+            "IFCRELAGGREGATES('{}',$,$,$,{},({}))",
+            ifc_guid("rel-storey-spaces"),
+            Part21Writer::reference(storey),
+            join_refs(&space_ids)
+        ));
+    }
+    if !site_ids.is_empty() {
+        writer.add_entity(format!(
+            "IFCRELAGGREGATES('{}',$,$,$,{},({}))",
+            ifc_guid("rel-project-element-sites"),
+            Part21Writer::reference(project),
+            join_refs(&site_ids)
+        ));
+    }
 
     let text = writer.build().map_err(IfcExportError::Serialization)?;
     Ok((text, report))
@@ -1144,17 +1279,34 @@ fn write_property_sets(
     semantics: &IfcEntitySemantics,
     report: &mut IfcExportReport,
 ) {
-    for (set_name, properties) in &semantics.property_sets {
+    // Sorted iteration: HashMap order is arbitrary and the SPF output must be
+    // deterministic across runs.
+    let mut set_names: Vec<&String> = semantics.property_sets.keys().collect();
+    set_names.sort();
+    for set_name in set_names {
+        let properties = &semantics.property_sets[set_name];
         if properties.is_empty() {
             continue;
         }
 
+        let mut property_names: Vec<&String> = properties.keys().collect();
+        property_names.sort();
         let mut property_ids = Vec::new();
-        for (property_name, property_value) in properties {
+        for property_name in property_names {
+            let property_value = &properties[property_name];
+            let literal = match property_value {
+                IfcPropertyValue::Bool(value) => {
+                    format!("IFCBOOLEAN({})", if *value { ".T." } else { ".F." })
+                }
+                IfcPropertyValue::Number(value) => format!("IFCREAL({})", format_real(*value)),
+                IfcPropertyValue::Text(value) => {
+                    format!("IFCTEXT('{}')", sanitize_string_literal(value))
+                }
+            };
             let property = writer.add_entity(format!(
-                "IFCPROPERTYSINGLEVALUE('{}',$,IFCTEXT('{}'),$)",
+                "IFCPROPERTYSINGLEVALUE('{}',$,{},$)",
                 sanitize_string_literal(property_name),
-                sanitize_string_literal(property_value)
+                literal
             ));
             property_ids.push(property);
         }
@@ -1184,17 +1336,22 @@ fn write_quantity_sets(
     semantics: &IfcEntitySemantics,
     report: &mut IfcExportReport,
 ) {
-    for (set_name, quantities) in &semantics.quantity_sets {
+    let mut set_names: Vec<&String> = semantics.quantity_sets.keys().collect();
+    set_names.sort();
+    for set_name in set_names {
+        let quantities = &semantics.quantity_sets[set_name];
         if quantities.is_empty() {
             continue;
         }
 
+        let mut quantity_names: Vec<&String> = quantities.keys().collect();
+        quantity_names.sort();
         let mut quantity_ids = Vec::new();
-        for (quantity_name, quantity_value) in quantities {
+        for quantity_name in quantity_names {
             let quantity = writer.add_entity(format!(
                 "IFCQUANTITYLENGTH('{}',$,$,{},$)",
                 sanitize_string_literal(quantity_name),
-                format_real(*quantity_value)
+                format_real(quantities[quantity_name])
             ));
             quantity_ids.push(quantity);
         }
@@ -1359,6 +1516,63 @@ mod tests {
         assert!(!text.contains("IFCTRIANGULATEDFACESET("));
     }
 
+    /// A tetrahedron whose apex is at source (1, 3, 2) so the Y-up/Z-up
+    /// distinction is unambiguous (no zero components on the apex).
+    fn oriented_tetrahedron() -> Brep {
+        let mut builder = BrepBuilder::new(Uuid::new_v4());
+        builder.add_vertices(&[
+            Vector3::new(0.0, 0.0, 0.0),
+            Vector3::new(4.0, 0.0, 0.0),
+            Vector3::new(0.0, 0.0, 4.0),
+            Vector3::new(1.0, 3.0, 2.0),
+        ]);
+        builder.add_face(&[0, 2, 1], &[]).unwrap();
+        builder.add_face(&[0, 1, 3], &[]).unwrap();
+        builder.add_face(&[1, 2, 3], &[]).unwrap();
+        builder.add_face(&[2, 0, 3], &[]).unwrap();
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn up_axis_conversion_default_maps_y_to_z() {
+        // Default config has up_axis_conversion = true: source apex
+        // (1, 3, 2) -> IFC (1, -2, 3).
+        let brep = oriented_tetrahedron();
+        let (text, _) =
+            export_brep_to_ifc_text(&brep, &IfcExportConfig::default()).expect("ifc export");
+        assert!(
+            text.contains("(1.0,-2.0,3.0)"),
+            "apex should be Z-up (1,-2,3); got:\n{}",
+            text
+        );
+        assert!(
+            !text.contains("(1.0,3.0,2.0)"),
+            "source Y-up apex must not appear when conversion is on"
+        );
+    }
+
+    #[test]
+    fn up_axis_conversion_off_preserves_source_coordinates() {
+        // Flag off: geometry is emitted exactly as authored.
+        let brep = oriented_tetrahedron();
+        let config = IfcExportConfig {
+            up_axis_conversion: false,
+            ..IfcExportConfig::default()
+        };
+        let (text, _) = export_brep_to_ifc_text(&brep, &config).expect("ifc export");
+        assert!(
+            text.contains("(1.0,3.0,2.0)"),
+            "apex should be unchanged (1,3,2) when conversion is off; got:\n{}",
+            text
+        );
+        assert!(!text.contains("(1.0,-2.0,3.0)"));
+    }
+
+    #[test]
+    fn up_axis_conversion_config_defaults_true() {
+        assert!(IfcExportConfig::default().up_axis_conversion);
+    }
+
     #[test]
     fn applies_semantics_class_when_supported() {
         let brep = tetrahedron_brep();
@@ -1404,5 +1618,158 @@ mod tests {
 
         let result = export_brep_to_ifc_text(&brep, &config);
         assert!(result.is_err());
+    }
+
+    /// IFCSPACE exports as a real space — its own attribute signature,
+    /// AGGREGATED under the storey rather than contained in it — instead of
+    /// degrading to a building element proxy.
+    #[test]
+    fn exports_space_as_aggregated_spatial_element() {
+        let brep = tetrahedron_brep();
+
+        let mut semantics = HashMap::new();
+        semantics.insert(
+            "brep-0".to_string(),
+            IfcEntitySemantics {
+                ifc_class: Some("IfcSpace".to_string()),
+                name: Some("Living Room".to_string()),
+                object_type: Some("residential".to_string()),
+                ..IfcEntitySemantics::default()
+            },
+        );
+
+        let config = IfcExportConfig {
+            semantics: Some(semantics),
+            error_policy: IfcErrorPolicy::Strict,
+            ..IfcExportConfig::default()
+        };
+
+        let (text, report) = export_brep_to_ifc_text(&brep, &config).expect("ifc export");
+        assert!(text.contains("IFCSPACE("), "space class applied");
+        assert!(
+            !text.contains("IFCBUILDINGELEMENTPROXY("),
+            "no proxy fallback"
+        );
+        assert!(
+            !text.contains("IFCRELCONTAINEDINSPATIALSTRUCTURE("),
+            "a lone space is not contained-in-storey"
+        );
+        assert!(
+            text.contains("'residential'"),
+            "object type (program/usage) survives"
+        );
+        // Storey → space aggregation exists (beyond the 3 scaffold aggregates).
+        assert_eq!(text.matches("IFCRELAGGREGATES(").count(), 4);
+        assert_eq!(report.semantics_applied, 1);
+        assert_eq!(report.proxy_fallbacks, 0);
+    }
+
+    /// IFCSITE exports with the site attribute signature, aggregated under the
+    /// project (a project may hold several sites).
+    #[test]
+    fn exports_site_aggregated_under_project() {
+        let brep = tetrahedron_brep();
+
+        let mut semantics = HashMap::new();
+        semantics.insert(
+            "brep-0".to_string(),
+            IfcEntitySemantics {
+                ifc_class: Some("IFCSITE".to_string()),
+                name: Some("Parcel 12".to_string()),
+                ..IfcEntitySemantics::default()
+            },
+        );
+
+        let config = IfcExportConfig {
+            semantics: Some(semantics),
+            error_policy: IfcErrorPolicy::Strict,
+            ..IfcExportConfig::default()
+        };
+
+        let (text, _) = export_brep_to_ifc_text(&brep, &config).expect("ifc export");
+        // Scaffold site + the exported parcel site.
+        assert_eq!(text.matches("IFCSITE(").count(), 2);
+        assert!(text.contains("'Parcel 12'"));
+        assert!(!text.contains("IFCRELCONTAINEDINSPATIALSTRUCTURE("));
+    }
+
+    /// Property sets carry TYPED values (IFCREAL / IFCBOOLEAN / IFCTEXT) and
+    /// the writer's output is deterministic (sorted set / property names).
+    #[test]
+    fn writes_typed_property_sets() {
+        let brep = tetrahedron_brep();
+
+        let mut properties = HashMap::new();
+        properties.insert("gfaM2".to_string(), IfcPropertyValue::Number(4500.25));
+        properties.insert(
+            "program".to_string(),
+            IfcPropertyValue::Text("office".to_string()),
+        );
+        properties.insert("compliant".to_string(), IfcPropertyValue::Bool(true));
+        let mut property_sets = HashMap::new();
+        property_sets.insert("OpenPlans_Yield".to_string(), properties);
+
+        let mut quantities = HashMap::new();
+        quantities.insert("NetSideArea".to_string(), 3735.5);
+        let mut quantity_sets = HashMap::new();
+        quantity_sets.insert("Qto_SpaceBaseQuantities".to_string(), quantities);
+
+        let mut semantics = HashMap::new();
+        semantics.insert(
+            "brep-0".to_string(),
+            IfcEntitySemantics {
+                ifc_class: Some("IFCSPACE".to_string()),
+                property_sets,
+                quantity_sets,
+                ..IfcEntitySemantics::default()
+            },
+        );
+
+        let config = IfcExportConfig {
+            semantics: Some(semantics),
+            error_policy: IfcErrorPolicy::Strict,
+            ..IfcExportConfig::default()
+        };
+
+        let (text, report) = export_brep_to_ifc_text(&brep, &config).expect("ifc export");
+        assert!(text.contains("IFCPROPERTYSINGLEVALUE('gfaM2',$,IFCREAL(4500.25),$)"));
+        assert!(text.contains("IFCPROPERTYSINGLEVALUE('program',$,IFCTEXT('office'),$)"));
+        assert!(text.contains("IFCPROPERTYSINGLEVALUE('compliant',$,IFCBOOLEAN(.T.),$)"));
+        assert!(text.contains("IFCPROPERTYSET("));
+        assert!(text.contains("IFCELEMENTQUANTITY("));
+        assert!(text.contains("IFCRELDEFINESBYPROPERTIES("));
+        assert_eq!(report.property_sets_written, 1);
+        assert_eq!(report.quantity_sets_written, 1);
+
+        let (again, _) = export_brep_to_ifc_text(
+            &brep,
+            &IfcExportConfig {
+                semantics: config.semantics.clone(),
+                error_policy: IfcErrorPolicy::Strict,
+                ..IfcExportConfig::default()
+            },
+        )
+        .expect("ifc export");
+        assert_eq!(text, again, "SPF output is deterministic across runs");
+    }
+
+    /// Legacy string-only property-set JSON still parses (untagged enum).
+    #[test]
+    fn legacy_string_property_sets_still_parse() {
+        let json = r#"{
+            "ifc_class": "IFCWALL",
+            "property_sets": { "Custom": { "material": "brick", "rating": "A" } }
+        }"#;
+        let semantics: IfcEntitySemantics =
+            serde_json::from_str(json).expect("legacy semantics parse");
+        let set = &semantics.property_sets["Custom"];
+        assert_eq!(set["material"], IfcPropertyValue::Text("brick".to_string()));
+
+        let typed = r#"{ "property_sets": { "Yield": { "gfa": 12.5, "ok": true } } }"#;
+        let semantics: IfcEntitySemantics =
+            serde_json::from_str(typed).expect("typed semantics parse");
+        let set = &semantics.property_sets["Yield"];
+        assert_eq!(set["gfa"], IfcPropertyValue::Number(12.5));
+        assert_eq!(set["ok"], IfcPropertyValue::Bool(true));
     }
 }

--- a/main/opengeometry/src/export/mod.rs
+++ b/main/opengeometry/src/export/mod.rs
@@ -10,7 +10,7 @@ pub mod pdf;
 pub use ifc::{
     export_brep_to_ifc_text, export_breps_to_ifc_text, export_scene_entities_to_ifc_text,
     IfcEntityInput, IfcEntitySemantics, IfcErrorPolicy, IfcExportConfig, IfcExportError,
-    IfcExportReport, IfcSchemaVersion,
+    IfcExportReport, IfcPropertyValue, IfcSchemaVersion,
 };
 pub use projection::{
     project_brep_to_scene, CameraParameters, ClassifiedSegment, EdgeClass, HlrOptions, Line2D,

--- a/main/opengeometry/src/geometry/boolean2d.rs
+++ b/main/opengeometry/src/geometry/boolean2d.rs
@@ -182,17 +182,33 @@ pub fn resolve_ring_nonzero(input: &[Pt2], eps: f64) -> Option<RingRegion> {
     Some(RingRegion { outer, holes })
 }
 
-// ── Multi-contour nonzero-winding union (overlapping-band merge) ──────────────
-// Union a set of CCW polygons (per-segment offset bands) into their filled-region
-// boundary by the NONZERO-WINDING rule: build the planar arrangement (split every
-// edge at all crossings + vertex-touches), keep only sub-edges that separate filled
-// (winding ≠ 0) from empty, orient them filled-on-LEFT, and stitch into loops. Where
-// bands OVERLAP (a self-crossing) the shared interior edges have filled on both
-// sides → dropped, so the overlap merges into one clean region. Pure 2D, no CSG —
-// the crossing cleanup the single-ring offset cannot do.
+// ── Multi-contour winding boolean (overlapping-band merge / oriented clip) ────
+// Resolve a set of ORIENTED polygons into their filled-region boundary by a
+// winding rule: build the planar arrangement (split every edge at all crossings
+// + vertex-touches), keep only sub-edges that separate filled from empty,
+// orient them filled-on-LEFT, and stitch into loops. Where contours OVERLAP the
+// shared interior edges have filled on both sides → dropped. Pure 2D, no CSG.
+//
+// `union_polygons_nonzero` (winding ≠ 0, all-CCW inputs) is the overlapping
+// stroke-band merge; `resolve_polygons_positive` (winding > 0) treats CCW rings
+// as additive and CW rings as subtractive — the clip a setback envelope needs.
 
+/// Union CCW polygons by the NONZERO-WINDING rule (the crossing cleanup the
+/// single-ring offset cannot do).
 pub fn union_polygons_nonzero(polys: &[Vec<Pt2>], eps: f64) -> Vec<RingRegion> {
-    // 1. directed edges from all (CCW) polygons + the vertex set for T-touch splits.
+    winding_regions(polys, eps, |winding| winding != 0)
+}
+
+/// Boundary of the POSITIVE-winding area of oriented rings: each CCW ring adds
+/// +1, each CW ring −1, and a point is filled when the sum is > 0. With one CCW
+/// base ring and CW cutters this is base-minus-cutters, keeping EVERY disjoint
+/// remainder (a clip can split the base into separate regions).
+pub fn resolve_polygons_positive(polys: &[Vec<Pt2>], eps: f64) -> Vec<RingRegion> {
+    winding_regions(polys, eps, |winding| winding > 0)
+}
+
+fn winding_regions(polys: &[Vec<Pt2>], eps: f64, filled: impl Fn(i32) -> bool) -> Vec<RingRegion> {
+    // 1. directed edges from all oriented polygons + the vertex set for T-touch splits.
     let mut edges: Vec<Edge2> = Vec::new();
     for poly in polys {
         let m = poly.len();
@@ -260,8 +276,8 @@ pub fn union_polygons_nonzero(polys: &[Vec<Pt2>], eps: f64) -> Vec<RingRegion> {
         let nz = dx / len;
         let mx = (a.x + b.x) / 2.0;
         let mz = (a.z + b.z) / 2.0;
-        let left = winding_at(Pt2::new(mx + nx * probe, mz + nz * probe)) != 0;
-        let right = winding_at(Pt2::new(mx - nx * probe, mz - nz * probe)) != 0;
+        let left = filled(winding_at(Pt2::new(mx + nx * probe, mz + nz * probe)));
+        let right = filled(winding_at(Pt2::new(mx - nx * probe, mz - nz * probe)));
         if left == right {
             continue; // interior or exterior — not a boundary
         }
@@ -271,6 +287,12 @@ pub fn union_polygons_nonzero(polys: &[Vec<Pt2>], eps: f64) -> Vec<RingRegion> {
             boundary.push((b, a));
         }
     }
+    // Drop coincident duplicates (e.g. two contours sharing a corner emit the
+    // same geometric boundary twice): both copies pass the probe test and the
+    // stitcher would trace the same loop twice.
+    let mut seen: std::collections::HashSet<((i64, i64), (i64, i64))> =
+        std::collections::HashSet::new();
+    boundary.retain(|&(a, b)| seen.insert((qkey(a), qkey(b))));
     if boundary.is_empty() {
         return Vec::new();
     }
@@ -350,4 +372,91 @@ pub fn union_polygons_nonzero(polys: &[Vec<Pt2>], eps: f64) -> Vec<RingRegion> {
         }
     }
     regions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn p(x: f64, z: f64) -> Pt2 {
+        Pt2::new(x, z)
+    }
+
+    fn ccw_square(x0: f64, z0: f64, x1: f64, z1: f64) -> Vec<Pt2> {
+        vec![p(x0, z0), p(x1, z0), p(x1, z1), p(x0, z1)]
+    }
+
+    fn cw(mut ring: Vec<Pt2>) -> Vec<Pt2> {
+        ring.reverse();
+        ring
+    }
+
+    /// A CW cutter strictly inside a CCW base subtracts to an annulus:
+    /// one region whose hole is the cutter.
+    #[test]
+    fn positive_clip_inner_cutter_makes_a_hole() {
+        let base = ccw_square(0.0, 0.0, 10.0, 10.0);
+        let cutter = cw(ccw_square(4.0, 4.0, 6.0, 6.0));
+        let regions = resolve_polygons_positive(&[base, cutter], DEFAULT_EPS);
+        assert_eq!(regions.len(), 1, "one annular region");
+        assert_eq!(regions[0].holes.len(), 1, "the cutter is its hole");
+        assert!((signed_area2(&regions[0].outer) - 100.0).abs() < 1e-6);
+        assert!(
+            (signed_area2(&regions[0].holes[0]) + 4.0).abs() < 1e-6,
+            "hole is CW, area -4"
+        );
+    }
+
+    /// A CW cutter spanning the base's full width splits it into TWO disjoint
+    /// remainder regions — every remainder is kept, not just the largest.
+    #[test]
+    fn positive_clip_keeps_every_disjoint_remainder() {
+        let base = ccw_square(0.0, 0.0, 10.0, 10.0);
+        let cutter = cw(ccw_square(-1.0, 4.0, 11.0, 6.0));
+        let regions = resolve_polygons_positive(&[base, cutter], DEFAULT_EPS);
+        assert_eq!(regions.len(), 2, "the band splits the base in two");
+        for region in &regions {
+            assert!(
+                (signed_area2(&region.outer) - 40.0).abs() < 1e-6,
+                "each half is 10×4"
+            );
+            assert!(region.holes.is_empty());
+        }
+    }
+
+    /// Cutters covering the whole base leave nothing — and a lone CW ring is
+    /// nothing too (no positive area anywhere), where the nonzero rule fills it.
+    #[test]
+    fn positive_clip_total_cover_and_lone_cutter_are_empty() {
+        let base = ccw_square(0.0, 0.0, 4.0, 4.0);
+        let cutter = cw(ccw_square(-1.0, -1.0, 5.0, 5.0));
+        assert!(resolve_polygons_positive(&[base, cutter], DEFAULT_EPS).is_empty());
+
+        let lone = cw(ccw_square(0.0, 0.0, 1.0, 1.0));
+        assert!(resolve_polygons_positive(&[lone.clone()], DEFAULT_EPS).is_empty());
+        assert_eq!(
+            union_polygons_nonzero(&[lone], DEFAULT_EPS).len(),
+            1,
+            "contrast: the nonzero rule fills a lone CW ring"
+        );
+    }
+
+    /// Overlapping cutters merge: clearance bands from adjacent parcel edges
+    /// carve one connected bite, not internal-edge artifacts.
+    #[test]
+    fn positive_clip_overlapping_cutters_merge() {
+        let base = ccw_square(0.0, 0.0, 10.0, 10.0);
+        let cutter_a = cw(ccw_square(-1.0, -1.0, 3.0, 3.0));
+        let cutter_b = cw(ccw_square(1.0, 1.0, 4.0, 2.0));
+        let regions = resolve_polygons_positive(&[base, cutter_a, cutter_b], DEFAULT_EPS);
+        assert_eq!(regions.len(), 1);
+        let region = &regions[0];
+        assert!(region.holes.is_empty());
+        assert!(
+            !self_intersects2(&region.outer, DEFAULT_EPS),
+            "merged outline is simple"
+        );
+        let expected = 100.0 - 9.0 - 1.0; // corner bite 3×3 (clipped to base) + 1×1 extra strip
+        assert!((signed_area2(&region.outer) - expected).abs() < 1e-6);
+    }
 }

--- a/main/opengeometry/src/geometry/offset2d.rs
+++ b/main/opengeometry/src/geometry/offset2d.rs
@@ -1,8 +1,8 @@
 //! Generic 2D polyline offset: miter/bevel joins, mitered bands, offset outline.
 
-use openmaths::Vector3;
-use crate::geometry::poly2d::*;
 use crate::geometry::boolean2d::*;
+use crate::geometry::poly2d::*;
+use openmaths::Vector3;
 
 /// Whether a centreline is (or should be treated as) a closed loop: the caller's
 /// `closed` flag OR a first≈last coincidence. Returns the working points (closing
@@ -153,10 +153,26 @@ pub fn mitered_offset_bands(
         let prev_seg = (i + seg_count - 1) % seg_count;
         let next_seg = (i + 1) % seg_count;
         let mut quad: Vec<Pt2> = vec![
-            if start_free { cap(start_vi, i, 1.0) } else { corner(start_vi, prev_seg, i, 1.0, i) },
-            if end_free { cap(end_vi, i, 1.0) } else { corner(end_vi, i, next_seg, 1.0, i) },
-            if end_free { cap(end_vi, i, -1.0) } else { corner(end_vi, i, next_seg, -1.0, i) },
-            if start_free { cap(start_vi, i, -1.0) } else { corner(start_vi, prev_seg, i, -1.0, i) },
+            if start_free {
+                cap(start_vi, i, 1.0)
+            } else {
+                corner(start_vi, prev_seg, i, 1.0, i)
+            },
+            if end_free {
+                cap(end_vi, i, 1.0)
+            } else {
+                corner(end_vi, i, next_seg, 1.0, i)
+            },
+            if end_free {
+                cap(end_vi, i, -1.0)
+            } else {
+                corner(end_vi, i, next_seg, -1.0, i)
+            },
+            if start_free {
+                cap(start_vi, i, -1.0)
+            } else {
+                corner(start_vi, prev_seg, i, -1.0, i)
+            },
         ];
         if self_intersects2(&quad, eps) || signed_area2(&quad).abs() < eps {
             // Over-deep trim folded the quad — fall back to a plain rectangle band.
@@ -178,7 +194,12 @@ pub fn mitered_offset_bands(
 /// Replace sharp convex miter spikes on a 2D ring with a flat BEVEL (the chamfer
 /// joining the two offset points), past `miter_limit` — the same threshold the
 /// per-corner joins use. Concave vertices and corners within the limit are kept.
-pub fn bevel_sharp_convex_pts(ring: &[Pt2], half_width: f64, miter_limit: f64, eps: f64) -> Vec<Pt2> {
+pub fn bevel_sharp_convex_pts(
+    ring: &[Pt2],
+    half_width: f64,
+    miter_limit: f64,
+    eps: f64,
+) -> Vec<Pt2> {
     let count = ring.len();
     if count < 3 {
         return ring.to_vec();
@@ -220,8 +241,14 @@ pub fn bevel_sharp_convex_pts(ring: &[Pt2], half_width: f64, miter_limit: f64, e
             out.push(vertex);
             continue;
         }
-        out.push(Pt2::new(vertex.x + to_prev.x * trim, vertex.z + to_prev.z * trim));
-        out.push(Pt2::new(vertex.x + to_next.x * trim, vertex.z + to_next.z * trim));
+        out.push(Pt2::new(
+            vertex.x + to_prev.x * trim,
+            vertex.z + to_prev.z * trim,
+        ));
+        out.push(Pt2::new(
+            vertex.x + to_next.x * trim,
+            vertex.z + to_next.z * trim,
+        ));
     }
     out
 }
@@ -308,20 +335,21 @@ pub fn offset_outline(
         left_normal.push(Pt2::new(-dz / length, dx / length));
     }
 
-    let points_at = |vi: usize, in_seg: usize, out_seg: usize, side: f64, forward: bool| -> Vec<Pt2> {
-        join_points(
-            pts[vi],
-            dir[in_seg],
-            dir[out_seg],
-            left_normal[in_seg],
-            left_normal[out_seg],
-            side,
-            half_width,
-            miter_limit,
-            eps,
-            forward,
-        )
-    };
+    let points_at =
+        |vi: usize, in_seg: usize, out_seg: usize, side: f64, forward: bool| -> Vec<Pt2> {
+            join_points(
+                pts[vi],
+                dir[in_seg],
+                dir[out_seg],
+                left_normal[in_seg],
+                left_normal[out_seg],
+                side,
+                half_width,
+                miter_limit,
+                eps,
+                forward,
+            )
+        };
     let cap = |vi: usize, seg: usize, side: f64| -> Pt2 {
         Pt2::new(
             pts[vi].x + side * half_width * left_normal[seg].x,

--- a/main/opengeometry/src/geometry/offset_regions.rs
+++ b/main/opengeometry/src/geometry/offset_regions.rs
@@ -3,11 +3,11 @@
 //! generic `geometry` 2D toolkit. Domain-neutral (walls, roads, pipe routes,
 //! hatching, font strokes, etc.).
 
+use crate::geometry::boolean2d::*;
+use crate::geometry::offset2d::*;
+use crate::geometry::poly2d::*;
 use openmaths::Vector3;
 use wasm_bindgen::prelude::*;
-use crate::geometry::poly2d::*;
-use crate::geometry::offset2d::*;
-use crate::geometry::boolean2d::*;
 
 /// One stroked region: a CW outer ring + its CCW inner-void holes (canonical).
 pub type OffsetRegion = (Vec<Vector3>, Vec<Vec<Vector3>>);
@@ -72,7 +72,9 @@ pub fn offset_polyline_regions(
 /// lift to `base_y`, normalise winding (CW outer / CCW holes), canonicalise.
 pub fn finalize_region(outer: &[Pt2], hole_rings: &[Vec<Pt2>], base_y: f64) -> OffsetRegion {
     let to_v3 = |ring: &[Pt2]| -> Vec<Vector3> {
-        ring.iter().map(|p| Vector3::new(p.x, base_y, p.z)).collect()
+        ring.iter()
+            .map(|p| Vector3::new(p.x, base_y, p.z))
+            .collect()
     };
     let outer = canonical_ring(&normalize_winding(&to_v3(outer), Winding::Cw));
     let holes = hole_rings
@@ -80,6 +82,139 @@ pub fn finalize_region(outer: &[Pt2], hole_rings: &[Vec<Pt2>], base_y: f64) -> O
         .map(|hole| canonical_ring(&normalize_winding(&to_v3(hole), Winding::Ccw)))
         .collect();
     (outer, holes)
+}
+
+/// Segments per stadium end-cap semicircle. Caps are CIRCUMSCRIBED tangent
+/// fans, so the forbidden zone always CONTAINS the exact clearance disc — the
+/// envelope can under-claim by the tessellation sliver (≈0.9 % radially at 12
+/// segments) but can never claim a point closer to an edge than its distance.
+const STADIUM_CAP_SEGMENTS: usize = 12;
+
+/// The forbidden zone of one edge: every point within `distance` of the
+/// segment a→b — a stadium (rectangle + two circumscribed end-cap fans),
+/// wound CW so it subtracts under the positive-winding rule.
+fn forbidden_stadium(a: Pt2, b: Pt2, distance: f64) -> Vec<Pt2> {
+    let length = (b.x - a.x).hypot(b.z - a.z);
+    let u = Pt2::new((b.x - a.x) / length, (b.z - a.z) / length);
+    let n = Pt2::new(-u.z, u.x);
+
+    let cap = |centre: Pt2, from_angle: f64| -> Vec<Pt2> {
+        // Tangent fan sweeping a semicircle CLOCKWISE from `from_angle`:
+        // vertices at the tangent-line intersections, radius d / cos(Δ/2).
+        let delta = std::f64::consts::PI / STADIUM_CAP_SEGMENTS as f64;
+        let radius = distance / (delta / 2.0).cos();
+        (0..STADIUM_CAP_SEGMENTS)
+            .map(|j| {
+                let angle = from_angle - (j as f64 + 0.5) * delta;
+                Pt2::new(
+                    centre.x + radius * angle.cos(),
+                    centre.z + radius * angle.sin(),
+                )
+            })
+            .collect()
+    };
+
+    let normal_angle = n.z.atan2(n.x);
+    let mut ring: Vec<Pt2> = Vec::with_capacity(4 + 2 * STADIUM_CAP_SEGMENTS);
+    ring.push(Pt2::new(a.x + distance * n.x, a.z + distance * n.z));
+    ring.push(Pt2::new(b.x + distance * n.x, b.z + distance * n.z));
+    ring.extend(cap(b, normal_angle)); // sweep through +u, beyond b
+    ring.push(Pt2::new(b.x - distance * n.x, b.z - distance * n.z));
+    ring.push(Pt2::new(a.x - distance * n.x, a.z - distance * n.z));
+    ring.extend(cap(a, normal_angle + std::f64::consts::PI)); // through -u, beyond a
+    ring // n = u rotated +90°, so this traversal is CW (winding −1)
+}
+
+/// Inset a CLOSED ring inward, one distance per edge (edge i = ring[i] →
+/// ring[i+1], after stripping an optional closing duplicate). The result is
+/// the CLEARANCE-EXACT buildable region: the ring's interior minus, per edge,
+/// every point within that edge's distance of the edge SEGMENT (not just its
+/// line) — resolved as a positive-winding clip of the ring against per-edge
+/// forbidden stadiums. Corners therefore become circumscribed clearance arcs
+/// where distances differ (no miters, no bevels — both only approximate the
+/// arc, and a bevel would violate the clearance), distant edges are honoured
+/// across notches, and an over-deep inset collapses to nothing instead of
+/// inverting. Returns zero or more disjoint regions (a deep inset can split a
+/// waisted ring into separate lobes), each CW-outer / CCW-holes, canonicalised
+/// — the same output contract as `offset_polyline_regions`. `Ok(vec![])` = the
+/// inset collapsed or the input ring is degenerate; `Err` = malformed
+/// ARGUMENTS (distance count mismatch, negative / non-finite distance).
+pub fn offset_ring_variable(
+    ring: &[Vector3],
+    distances: &[f64],
+    eps: f64,
+) -> Result<Vec<OffsetRegion>, String> {
+    let base_y = ring.first().map(|v| v.y).unwrap_or(0.0);
+    let raw: Vec<Pt2> = ring.iter().map(xz).collect();
+    let (pts, _) = resolve_closed(&raw, true, eps);
+    let n = pts.len();
+
+    if distances.len() != n {
+        return Err(format!(
+            "Expected one distance per ring edge (edge i = ring[i] -> ring[i+1]): the ring has {} edges but {} distances were given",
+            n,
+            distances.len()
+        ));
+    }
+    for (i, d) in distances.iter().enumerate() {
+        if !d.is_finite() || *d < 0.0 {
+            return Err(format!(
+                "distances[{}] = {} is invalid: every per-edge distance must be a finite value >= 0",
+                i, d
+            ));
+        }
+    }
+
+    // Drop zero-length edges together with their distance slot, so the
+    // per-edge pairing stays aligned. (`simplify_polyline` is deliberately not
+    // used: its width-based vertex dropping would desync `distances`, and a
+    // collinear vertex splitting one frontage into different setbacks is a
+    // feature, not noise.)
+    let mut pts2: Vec<Pt2> = Vec::with_capacity(n);
+    let mut dist2: Vec<f64> = Vec::with_capacity(n);
+    for i in 0..n {
+        let a = pts[i];
+        let b = pts[(i + 1) % n];
+        if (a.x - b.x).hypot(a.z - b.z) < eps {
+            continue;
+        }
+        pts2.push(a);
+        dist2.push(distances[i]);
+    }
+
+    let m = pts2.len();
+    if m < 3 || signed_area2(&pts2).abs() <= eps || self_intersects2(&pts2, eps) {
+        return Ok(Vec::new()); // geometrically unbuildable input — empty, not an error
+    }
+
+    // The clip needs the base ring CCW (+1) against CW cutters (−1).
+    if signed_area2(&pts2) < 0.0 {
+        pts2.reverse();
+        let old = dist2.clone();
+        // Reversal turns edge k into traversed-backward edge (m-2-k) mod m, so
+        // the per-edge distances are remapped the same way.
+        for (k, slot) in dist2.iter_mut().enumerate() {
+            *slot = old[(2 * m - 2 - k) % m];
+        }
+    }
+
+    if dist2.iter().all(|d| *d == 0.0) {
+        return Ok(vec![finalize_region(&pts2, &[], base_y)]); // no-op inset
+    }
+
+    let mut polys: Vec<Vec<Pt2>> = Vec::with_capacity(1 + m);
+    polys.push(pts2.clone());
+    for i in 0..m {
+        if dist2[i] > 0.0 {
+            polys.push(forbidden_stadium(pts2[i], pts2[(i + 1) % m], dist2[i]));
+        }
+    }
+
+    Ok(resolve_polygons_positive(&polys, eps)
+        .into_iter()
+        .filter(|region| signed_area2(&region.outer).abs() > eps)
+        .map(|region| finalize_region(&region.outer, &region.holes, base_y))
+        .collect())
 }
 
 /// One polyline in an offset group: its centreline, stroke width, and closed flag.
@@ -117,7 +252,13 @@ pub fn offset_polyline_group_regions(
         }
         let raw: Vec<Pt2> = simplified.iter().map(xz).collect();
         let (pts, is_closed) = resolve_closed(&raw, polyline.closed, eps);
-        bands.extend(mitered_offset_bands(&pts, is_closed, half, f64::INFINITY, eps));
+        bands.extend(mitered_offset_bands(
+            &pts,
+            is_closed,
+            half,
+            f64::INFINITY,
+            eps,
+        ));
     }
     if bands.is_empty() {
         return Vec::new();
@@ -215,8 +356,10 @@ struct OffsetPolylineJson {
 pub fn offset_polyline_group_regions_wasm(
     polylines_json: String,
 ) -> Result<OGOffsetRegionsResult, JsValue> {
-    let parsed: Vec<OffsetPolylineJson> = serde_json::from_str(&polylines_json)
-        .map_err(|error| JsValue::from_str(&format!("Invalid offset group JSON payload: {}", error)))?;
+    let parsed: Vec<OffsetPolylineJson> =
+        serde_json::from_str(&polylines_json).map_err(|error| {
+            JsValue::from_str(&format!("Invalid offset group JSON payload: {}", error))
+        })?;
     let polylines: Vec<OffsetPolyline> = parsed
         .into_iter()
         .filter(|polyline| polyline.centreline.len() % 3 == 0)
@@ -232,6 +375,35 @@ pub fn offset_polyline_group_regions_wasm(
         .collect();
 
     let regions = offset_polyline_group_regions(&polylines, DEFAULT_MITER_LIMIT, DEFAULT_EPS);
+    OGOffsetRegionsResult::from_regions(regions).map_err(|error| JsValue::from_str(&error))
+}
+
+/// Wasm entry point: inset a CLOSED ring inward with one distance per edge
+/// (edge i = ring[i] → ring[i+1]). `ring_flat` is `[x0,y0,z0, …]`. Returns
+/// CW-outer / CCW-hole regions, canonicalised; possibly several when a deep
+/// inset splits the ring, and empty (does NOT throw) when the inset collapses
+/// or the input ring is degenerate. THROWS on malformed arguments: a distance
+/// count that does not match the edge count, or a negative / non-finite
+/// distance. Corners where distances differ are circumscribed clearance arcs
+/// (conservative), so no output point is ever closer to edge i than
+/// `distances[i]` — there is no miter-limit knob because there are no miters.
+#[wasm_bindgen(js_name = offsetRingVariable)]
+pub fn offset_ring_variable_wasm(
+    ring_flat: Vec<f64>,
+    distances: Vec<f64>,
+) -> Result<OGOffsetRegionsResult, JsValue> {
+    if ring_flat.len() % 3 != 0 {
+        return Err(JsValue::from_str(
+            "Ring must be a flat [x,y,z,…] array whose length is a multiple of 3",
+        ));
+    }
+    let ring: Vec<Vector3> = ring_flat
+        .chunks_exact(3)
+        .map(|c| Vector3::new(c[0], c[1], c[2]))
+        .collect();
+
+    let regions = offset_ring_variable(&ring, &distances, DEFAULT_EPS)
+        .map_err(|error| JsValue::from_str(&error))?;
     OGOffsetRegionsResult::from_regions(regions).map_err(|error| JsValue::from_str(&error))
 }
 
@@ -267,8 +439,13 @@ mod tests {
     #[test]
     fn straight_offsets_by_half_width() {
         let centreline = vec![pt(0.0, 0.0), pt(2.0, 0.0)];
-        let (outer, holes) =
-            single(offset_polyline_regions(&centreline, 0.3, false, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
+        let (outer, holes) = single(offset_polyline_regions(
+            &centreline,
+            0.3,
+            false,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
         assert_eq!(outer.len(), 4, "a straight stroke is a 4-point rectangle");
         assert!(holes.is_empty(), "an open stroke has no holes");
         // Centreline runs along +x at z=0; offsets should be at z = ±0.15.
@@ -298,23 +475,44 @@ mod tests {
         let (outer, holes) = &regions[0];
         assert!(holes.is_empty(), "a simple cross has no interior void");
         let ring: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
-        assert!(!self_intersects2(&ring, DEFAULT_EPS), "merged outline is simple");
-        assert!(point_in_ring2(Pt2::new(0.0, 0.0), &ring), "crossing centre is filled");
+        assert!(
+            !self_intersects2(&ring, DEFAULT_EPS),
+            "merged outline is simple"
+        );
+        assert!(
+            point_in_ring2(Pt2::new(0.0, 0.0), &ring),
+            "crossing centre is filled"
+        );
         // A plus sign has 12 corners; certainly more than a single rectangle's 4.
-        assert!(outer.len() >= 8, "cross outline has the crossing's corners ({} pts)", outer.len());
+        assert!(
+            outer.len() >= 8,
+            "cross outline has the crossing's corners ({} pts)",
+            outer.len()
+        );
     }
 
     /// An open L stroke is one simple ring with no holes.
     #[test]
     fn open_l_is_a_simple_ring() {
         let centreline = vec![pt(0.0, 0.0), pt(2.0, 0.0), pt(2.0, 2.0), pt(4.0, 2.0)];
-        let (outer, holes) =
-            single(offset_polyline_regions(&centreline, 0.3, false, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
+        let (outer, holes) = single(offset_polyline_regions(
+            &centreline,
+            0.3,
+            false,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
         assert!(holes.is_empty(), "open chain has no holes");
         let ring: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
         assert!(ring.len() >= 4, "ring has at least 4 points");
-        assert!(!self_intersects2(&ring, DEFAULT_EPS), "outer ring must be simple");
-        assert!(signed_area2(&ring).abs() > DEFAULT_EPS, "outer ring must have area");
+        assert!(
+            !self_intersects2(&ring, DEFAULT_EPS),
+            "outer ring must be simple"
+        );
+        assert!(
+            signed_area2(&ring).abs() > DEFAULT_EPS,
+            "outer ring must have area"
+        );
     }
 
     /// A closed square loop produces an outer ring plus exactly one interior-void hole.
@@ -327,12 +525,24 @@ mod tests {
             pt(0.0, 4.0),
             pt(0.0, 0.0),
         ];
-        let (outer, holes) =
-            single(offset_polyline_regions(&centreline, 0.4, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
+        let (outer, holes) = single(offset_polyline_regions(
+            &centreline,
+            0.4,
+            true,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
         assert!(outer.len() >= 4, "outer ring has at least 4 points");
-        assert_eq!(holes.len(), 1, "closed loop has exactly one interior-void hole");
+        assert_eq!(
+            holes.len(),
+            1,
+            "closed loop has exactly one interior-void hole"
+        );
         let outer2: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
-        assert!(!self_intersects2(&outer2, DEFAULT_EPS), "outer ring must be simple");
+        assert!(
+            !self_intersects2(&outer2, DEFAULT_EPS),
+            "outer ring must be simple"
+        );
     }
 
     /// The offset is deterministic: the same input yields identical regions every call.
@@ -342,13 +552,17 @@ mod tests {
         let same = |a: &[Vector3], b: &[Vector3]| {
             a.len() == b.len()
                 && a.iter().zip(b).all(|(p, q)| {
-                    (p.x - q.x).abs() < 1e-12 && (p.y - q.y).abs() < 1e-12 && (p.z - q.z).abs() < 1e-12
+                    (p.x - q.x).abs() < 1e-12
+                        && (p.y - q.y).abs() < 1e-12
+                        && (p.z - q.z).abs() < 1e-12
                 })
         };
-        let baseline = offset_polyline_regions(&centreline, 0.3, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS);
+        let baseline =
+            offset_polyline_regions(&centreline, 0.3, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS);
         assert!(!baseline.is_empty(), "star offset builds");
         for _ in 0..8 {
-            let again = offset_polyline_regions(&centreline, 0.3, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS);
+            let again =
+                offset_polyline_regions(&centreline, 0.3, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS);
             assert_eq!(baseline.len(), again.len(), "region count must be stable");
             for ((o1, h1), (o2, h2)) in baseline.iter().zip(&again) {
                 assert!(same(o1, o2), "outer ring must be identical across calls");
@@ -371,12 +585,26 @@ mod tests {
             pt(0.0, 1.0),
             pt(0.0, 0.0),
         ];
-        let (outer, holes) =
-            single(offset_polyline_regions(&centreline, 1.0, true, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
-        assert!(holes.is_empty(), "the interior void is consumed → no hole (solid)");
+        let (outer, holes) = single(offset_polyline_regions(
+            &centreline,
+            1.0,
+            true,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
+        assert!(
+            holes.is_empty(),
+            "the interior void is consumed → no hole (solid)"
+        );
         let outer2: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
-        assert!(outer.len() >= 4 && !self_intersects2(&outer2, DEFAULT_EPS), "outer ring is a simple block");
-        assert!(signed_area2(&outer2).abs() > DEFAULT_EPS, "outer ring has area");
+        assert!(
+            outer.len() >= 4 && !self_intersects2(&outer2, DEFAULT_EPS),
+            "outer ring is a simple block"
+        );
+        assert!(
+            signed_area2(&outer2).abs() > DEFAULT_EPS,
+            "outer ring has area"
+        );
     }
 
     /// A self-crossing centreline (figure-8): the per-segment bands UNION by nonzero
@@ -414,9 +642,15 @@ mod tests {
             })
         };
         // The crossing centre (1.5,1.5) is MERGED — the two diagonal bands overlap there.
-        assert!(filled(Pt2::new(1.5, 1.5)), "crossing centre is filled (merged)");
+        assert!(
+            filled(Pt2::new(1.5, 1.5)),
+            "crossing centre is filled (merged)"
+        );
         // A point deep inside a lobe triangle is a void (the area the stroke encloses).
-        assert!(!filled(Pt2::new(0.6, 1.5)), "lobe interior is an empty void");
+        assert!(
+            !filled(Pt2::new(0.6, 1.5)),
+            "lobe interior is an empty void"
+        );
     }
 
     /// An acute open corner bevels (no runaway miter spike): the region stays a
@@ -424,14 +658,25 @@ mod tests {
     #[test]
     fn acute_open_corner_bevels_and_stays_bounded() {
         let centreline = vec![pt(0.0, 0.0), pt(5.0, 0.0), pt(2.0, 1.0)];
-        let (outer, holes) =
-            single(offset_polyline_regions(&centreline, 0.5, false, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
+        let (outer, holes) = single(offset_polyline_regions(
+            &centreline,
+            0.5,
+            false,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
         assert!(holes.is_empty(), "open stroke has no holes");
         let ring: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
-        assert!(!self_intersects2(&ring, DEFAULT_EPS), "outer ring is simple");
+        assert!(
+            !self_intersects2(&ring, DEFAULT_EPS),
+            "outer ring is simple"
+        );
         // A full miter at this acute apex would spike well past the centreline; the
         // bevel keeps every vertex within ~width of the centreline bbox (x≤5).
-        assert!(outer.iter().all(|v| v.x < 6.0), "no runaway miter spike (bevelled)");
+        assert!(
+            outer.iter().all(|v| v.x < 6.0),
+            "no runaway miter spike (bevelled)"
+        );
     }
 
     /// A doubling-back OPEN path (reflex hairpin) resolves by nonzero winding to a
@@ -439,11 +684,22 @@ mod tests {
     #[test]
     fn self_overlapping_open_path_resolves_simple() {
         let centreline = vec![pt(0.0, 0.0), pt(5.0, 0.0), pt(1.0, 0.4)];
-        let (outer, _holes) =
-            single(offset_polyline_regions(&centreline, 0.3, false, DEFAULT_MITER_LIMIT, DEFAULT_EPS));
+        let (outer, _holes) = single(offset_polyline_regions(
+            &centreline,
+            0.3,
+            false,
+            DEFAULT_MITER_LIMIT,
+            DEFAULT_EPS,
+        ));
         let ring: Vec<Pt2> = outer.iter().map(|v| Pt2::new(v.x, v.z)).collect();
-        assert!(!self_intersects2(&ring, DEFAULT_EPS), "resolved outer ring is simple");
-        assert!(signed_area2(&ring).abs() > DEFAULT_EPS, "outer ring has area");
+        assert!(
+            !self_intersects2(&ring, DEFAULT_EPS),
+            "resolved outer ring is simple"
+        );
+        assert!(
+            signed_area2(&ring).abs() > DEFAULT_EPS,
+            "outer ring has area"
+        );
     }
 
     #[test]
@@ -455,5 +711,393 @@ mod tests {
         assert!((simplified[0].x - 0.0).abs() < 1e-9);
         let last = simplified.last().unwrap();
         assert!((last.x - 3.0).abs() < 1e-9, "true endpoint preserved");
+    }
+
+    // ── offset_ring_variable ─────────────────────────────────────────────────
+
+    fn variable(ring: &[Vector3], distances: &[f64]) -> Result<Vec<OffsetRegion>, String> {
+        offset_ring_variable(ring, distances, DEFAULT_EPS)
+    }
+
+    fn ring2(region: &OffsetRegion) -> Vec<Pt2> {
+        region.0.iter().map(|v| Pt2::new(v.x, v.z)).collect()
+    }
+
+    /// Min distance from `p` to the segment a→b.
+    fn dist_to_segment(p: Pt2, a: Pt2, b: Pt2) -> f64 {
+        let abx = b.x - a.x;
+        let abz = b.z - a.z;
+        let len2 = abx * abx + abz * abz;
+        let t = if len2 > 0.0 {
+            (((p.x - a.x) * abx + (p.z - a.z) * abz) / len2).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        (p.x - (a.x + t * abx)).hypot(p.z - (a.z + t * abz))
+    }
+
+    fn has_vertex(ring: &[Vector3], x: f64, z: f64) -> bool {
+        ring.iter()
+            .any(|v| (v.x - x).abs() < 1e-9 && (v.z - z).abs() < 1e-9)
+    }
+
+    /// A uniform variable inset of a square equals the plain shrunken square.
+    #[test]
+    fn variable_inset_uniform_matches_square() {
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 20.0), pt(0.0, 20.0)];
+        let regions = variable(&ring, &[2.0; 4]).expect("valid arguments");
+        let (outer, holes) = single(regions);
+        assert!(holes.is_empty(), "an inward inset cannot create holes");
+        assert_eq!(outer.len(), 4, "square inset stays a quad");
+        for (x, z) in [(2.0, 2.0), (18.0, 2.0), (18.0, 18.0), (2.0, 18.0)] {
+            assert!(has_vertex(&outer, x, z), "missing corner ({}, {})", x, z);
+        }
+    }
+
+    /// Front/side/rear setbacks on a rectangle land each edge at its own distance.
+    #[test]
+    fn variable_inset_front_side_rear_setbacks() {
+        // 20 (x) × 30 (z); edge 0 = front (z=0, setback 6), edges 1/3 = sides
+        // (x=20 and x=0, setback 1.5), edge 2 = rear (z=30, setback 3).
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let regions = variable(&ring, &[6.0, 1.5, 3.0, 1.5]).expect("valid arguments");
+        let (outer, _) = single(regions);
+        assert_eq!(outer.len(), 4);
+        for (x, z) in [(1.5, 6.0), (18.5, 6.0), (18.5, 27.0), (1.5, 27.0)] {
+            assert!(has_vertex(&outer, x, z), "missing corner ({}, {})", x, z);
+        }
+        let area = signed_area2(&ring2(&(outer.clone(), Vec::new()))).abs();
+        assert!((area - 17.0 * 21.0).abs() < 1e-9, "area = {}", area);
+    }
+
+    /// A zero-distance edge stays exactly in place (lot-line construction).
+    #[test]
+    fn variable_inset_zero_distance_edge_stays() {
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let regions = variable(&ring, &[0.0, 1.5, 3.0, 1.5]).expect("valid arguments");
+        let (outer, _) = single(regions);
+        // The front edge (z = 0) is untouched: its inset corners sit on it.
+        assert!(has_vertex(&outer, 1.5, 0.0));
+        assert!(has_vertex(&outer, 18.5, 0.0));
+    }
+
+    /// All-zero distances are a legitimate no-op inset returning the input ring.
+    #[test]
+    fn variable_inset_all_zero_returns_input_ring() {
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let (outer, holes) = single(variable(&ring, &[0.0; 4]).expect("valid arguments"));
+        assert!(holes.is_empty());
+        assert_eq!(outer.len(), 4);
+        for (x, z) in [(0.0, 0.0), (20.0, 0.0), (20.0, 30.0), (0.0, 30.0)] {
+            assert!(has_vertex(&outer, x, z));
+        }
+    }
+
+    #[test]
+    fn variable_inset_distance_count_mismatch_errors() {
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let Err(error) = variable(&ring, &[6.0, 1.5, 3.0]) else {
+            panic!("count mismatch must throw");
+        };
+        assert!(
+            error.contains("4 edges"),
+            "message names the edge count: {}",
+            error
+        );
+        assert!(
+            error.contains("3 distances"),
+            "message names the given count: {}",
+            error
+        );
+    }
+
+    #[test]
+    fn variable_inset_negative_distance_errors() {
+        let ring = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let Err(error) = variable(&ring, &[6.0, -1.5, 3.0, 1.5]) else {
+            panic!("negative distance must throw");
+        };
+        assert!(
+            error.contains("distances[1]"),
+            "message names the index: {}",
+            error
+        );
+    }
+
+    /// A ring given with an explicit closing duplicate takes the same N distances
+    /// and produces the identical canonical result.
+    #[test]
+    fn variable_inset_accepts_closing_duplicate() {
+        let open = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let mut closed = open.clone();
+        closed.push(open[0]);
+        let distances = [6.0, 1.5, 3.0, 1.5];
+        let a = single(variable(&open, &distances).expect("open form"));
+        let b = single(variable(&closed, &distances).expect("closed form"));
+        assert_eq!(a.0.len(), b.0.len());
+        for (p, q) in a.0.iter().zip(&b.0) {
+            assert!((p.x - q.x).abs() < 1e-12 && (p.z - q.z).abs() < 1e-12);
+        }
+    }
+
+    /// A CW ring with reversal-remapped distances matches the CCW result.
+    #[test]
+    fn variable_inset_cw_input_matches_ccw() {
+        let ccw = vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)];
+        let ccw_d = [6.0, 1.5, 3.0, 1.5];
+        // Reversed point order: edge k of the CW ring is edge (n-2-k) mod n of
+        // the CCW ring traversed backward.
+        let cw: Vec<Vector3> = ccw.iter().rev().copied().collect();
+        let n = ccw.len();
+        let cw_d: Vec<f64> = (0..n).map(|k| ccw_d[(2 * n - 2 - k) % n]).collect();
+        let a = single(variable(&ccw, &ccw_d).expect("ccw"));
+        let b = single(variable(&cw, &cw_d).expect("cw"));
+        assert_eq!(a.0.len(), b.0.len());
+        for (p, q) in a.0.iter().zip(&b.0) {
+            assert!((p.x - q.x).abs() < 1e-12 && (p.z - q.z).abs() < 1e-12);
+        }
+    }
+
+    /// Splitting one frontage into two collinear edges with different distances
+    /// transitions between the two setback lines through the deeper edge's
+    /// clearance arc around the split point — NOT a perpendicular step, which
+    /// would claim points within the deep distance of the deep segment's
+    /// endpoint.
+    #[test]
+    fn variable_inset_collinear_split_edge_steps() {
+        let ring = vec![
+            pt(0.0, 0.0),
+            pt(10.0, 0.0), // split point on the z=0 frontage
+            pt(20.0, 0.0),
+            pt(20.0, 30.0),
+            pt(0.0, 30.0),
+        ];
+        let regions = variable(&ring, &[2.0, 5.0, 1.5, 3.0, 1.5]).expect("valid arguments");
+        let (outer, _) = single(regions);
+        let r2 = ring2(&(outer.clone(), Vec::new()));
+        assert!(
+            !self_intersects2(&r2, DEFAULT_EPS),
+            "stepped envelope is simple"
+        );
+        // Both setback lines exist…
+        assert!(
+            outer.iter().any(|v| (v.z - 2.0).abs() < 1e-9 && v.x < 5.5),
+            "shallow frontage line at z=2 (left of the deep edge's clearance arc)"
+        );
+        assert!(
+            outer
+                .iter()
+                .any(|v| (v.z - 5.0).abs() < 1e-9 && v.x > 10.0 - 1e-9),
+            "deep frontage line at z=5"
+        );
+        // …joined through the arc anchored at (10, 5) above the split point.
+        assert!(has_vertex(&outer, 10.0, 5.0), "arc anchor above the split");
+        // The would-be step corner (10, 2) is within 5 m of the deep frontage
+        // segment, so it must NOT be claimed.
+        let deep_a = Pt2::new(10.0, 0.0);
+        let deep_b = Pt2::new(20.0, 0.0);
+        for v in &outer {
+            assert!(
+                dist_to_segment(Pt2::new(v.x, v.z), deep_a, deep_b) >= 5.0 - 1.0e-6,
+                "vertex ({}, {}) violates the deep frontage clearance",
+                v.x,
+                v.z
+            );
+        }
+    }
+
+    /// Every output vertex keeps at least its edge's distance to that edge —
+    /// the compliance property a setback envelope exists to guarantee. Cases
+    /// include a sharp reflex notch (where a miter/bevel join would spike or
+    /// under-clear) and a deep notch whose far flank constrains points across
+    /// exterior space.
+    #[test]
+    fn variable_inset_clearance_respected() {
+        let cases: Vec<(Vec<Vector3>, Vec<f64>)> = vec![
+            (
+                vec![pt(0.0, 0.0), pt(20.0, 0.0), pt(20.0, 30.0), pt(0.0, 30.0)],
+                vec![6.0, 1.5, 3.0, 1.5],
+            ),
+            (
+                // Reflex notch in the top edge (sharp spike pointing into the lot).
+                vec![
+                    pt(0.0, 0.0),
+                    pt(40.0, 0.0),
+                    pt(40.0, 30.0),
+                    pt(22.0, 30.0),
+                    pt(20.0, 12.0), // notch tip — sharp reflex on both flanks
+                    pt(18.0, 30.0),
+                    pt(0.0, 30.0),
+                ],
+                vec![3.0, 2.0, 1.0, 2.5, 2.5, 1.0, 4.0],
+            ),
+        ];
+        for (ring, distances) in cases {
+            let raw: Vec<Pt2> = ring.iter().map(|v| Pt2::new(v.x, v.z)).collect();
+            let regions = offset_ring_variable(&ring, &distances, DEFAULT_EPS).expect("valid");
+            assert!(!regions.is_empty(), "inset builds");
+            for region in &regions {
+                for v in &region.0 {
+                    let p = Pt2::new(v.x, v.z);
+                    for i in 0..raw.len() {
+                        let clearance = dist_to_segment(p, raw[i], raw[(i + 1) % raw.len()]);
+                        assert!(
+                            clearance >= distances[i] - 1.0e-6,
+                            "vertex ({}, {}) is {} from edge {} (required {})",
+                            p.x,
+                            p.z,
+                            clearance,
+                            i,
+                            distances[i]
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Clearance applies to edge SEGMENTS across exterior space: a narrow
+    /// notch's far lot line constrains the envelope on the near side, exactly
+    /// like the service's per-edge compliance checker measures it.
+    #[test]
+    fn variable_inset_respects_distant_edges_across_a_notch() {
+        // A 2-wide exterior slot (x 10..12) cut into the top of a 30×20 lot.
+        let ring = vec![
+            pt(0.0, 0.0),
+            pt(30.0, 0.0),
+            pt(30.0, 20.0),
+            pt(12.0, 20.0),
+            pt(12.0, 8.0),
+            pt(10.0, 8.0), // slot bottom
+            pt(10.0, 20.0),
+            pt(0.0, 20.0),
+        ];
+        // Edge 5 = slot's left wall (10,8)→(10,20) faces the right lobe across
+        // the 2-wide slot with a 5 m clearance: it must carve into x ∈ (12, 15).
+        let distances = vec![1.0, 1.0, 1.0, 1.0, 1.0, 5.0, 1.0, 1.0];
+        let regions = variable(&ring, &distances).expect("valid arguments");
+        assert!(!regions.is_empty());
+        let wall_a = Pt2::new(10.0, 8.0);
+        let wall_b = Pt2::new(10.0, 20.0);
+        for region in &regions {
+            for v in &region.0 {
+                assert!(
+                    dist_to_segment(Pt2::new(v.x, v.z), wall_a, wall_b) >= 5.0 - 1.0e-6,
+                    "vertex ({}, {}) is inside the slot wall's clearance",
+                    v.x,
+                    v.z
+                );
+            }
+        }
+        // The point (13, 14) is only 3 m from the slot's left wall — across
+        // exterior space — and must be excluded from every region.
+        let probe = Pt2::new(13.0, 14.0);
+        for region in &regions {
+            let r2 = ring2(region);
+            assert!(
+                !point_in_ring2(probe, &r2),
+                "(13, 14) violates the slot wall clearance but was claimed"
+            );
+        }
+    }
+
+    /// Distances that consume the whole ring collapse to an empty result.
+    #[test]
+    fn variable_inset_collapse_returns_empty() {
+        let ring = vec![pt(0.0, 0.0), pt(4.0, 0.0), pt(4.0, 4.0), pt(0.0, 4.0)];
+        let regions = variable(&ring, &[3.0; 4]).expect("valid arguments");
+        assert!(
+            regions.is_empty(),
+            "fully consumed inset is empty, not an error"
+        );
+    }
+
+    /// A waisted (dumbbell) parcel whose waist is narrower than the side insets
+    /// splits into TWO disjoint envelope regions — the case the old
+    /// largest-hole stroke trick could not represent.
+    #[test]
+    fn variable_inset_dumbbell_splits_into_two_regions() {
+        let dumbbell = vec![
+            pt(0.0, 0.0),
+            pt(20.0, 0.0),
+            pt(20.0, 14.0), // waist starts: narrow corridor z 14..26 at x 8..12
+            pt(12.0, 14.0),
+            pt(12.0, 26.0),
+            pt(20.0, 26.0),
+            pt(20.0, 40.0),
+            pt(0.0, 40.0),
+            pt(0.0, 26.0),
+            pt(8.0, 26.0),
+            pt(8.0, 14.0),
+            pt(0.0, 14.0),
+        ];
+        // The corridor is 4 wide (x 8..12); a uniform 3.0 inset closes it but
+        // leaves both 20×14 lobes buildable.
+        let regions = variable(&dumbbell, &[3.0; 12]).expect("valid arguments");
+        assert_eq!(regions.len(), 2, "pinched waist splits the envelope in two");
+        let original: Vec<Pt2> = dumbbell.iter().map(|v| Pt2::new(v.x, v.z)).collect();
+        for region in &regions {
+            let r2 = ring2(region);
+            assert!(
+                r2.len() >= 3 && !self_intersects2(&r2, DEFAULT_EPS),
+                "each lobe is simple"
+            );
+            assert!(signed_area2(&r2).abs() > 1.0, "each lobe has real area");
+            assert!(
+                ring_inside2(&r2, &original, DEFAULT_EPS),
+                "lobes stay inside the parcel"
+            );
+        }
+    }
+
+    /// Degenerate rings (too few points, zero area, self-intersecting) are
+    /// empty results, not errors.
+    #[test]
+    fn variable_inset_degenerate_ring_is_empty() {
+        let two = vec![pt(0.0, 0.0), pt(10.0, 0.0)];
+        assert!(variable(&two, &[1.0, 1.0])
+            .expect("valid arguments")
+            .is_empty());
+        let collinear = vec![pt(0.0, 0.0), pt(10.0, 0.0), pt(20.0, 0.0)];
+        assert!(variable(&collinear, &[1.0; 3])
+            .expect("valid arguments")
+            .is_empty());
+        let bowtie = vec![pt(0.0, 0.0), pt(10.0, 10.0), pt(10.0, 0.0), pt(0.0, 10.0)];
+        assert!(variable(&bowtie, &[1.0; 4])
+            .expect("valid arguments")
+            .is_empty());
+    }
+
+    /// The variable inset is deterministic across repeated calls.
+    #[test]
+    fn variable_inset_deterministic() {
+        let ring = vec![
+            pt(0.0, 0.0),
+            pt(40.0, 0.0),
+            pt(40.0, 30.0),
+            pt(22.0, 30.0),
+            pt(20.0, 12.0),
+            pt(18.0, 30.0),
+            pt(0.0, 30.0),
+        ];
+        let distances = [3.0, 2.0, 1.0, 2.5, 2.5, 1.0, 4.0];
+        let same = |a: &[Vector3], b: &[Vector3]| {
+            a.len() == b.len()
+                && a.iter().zip(b).all(|(p, q)| {
+                    (p.x - q.x).abs() < 1e-12
+                        && (p.y - q.y).abs() < 1e-12
+                        && (p.z - q.z).abs() < 1e-12
+                })
+        };
+        let baseline = variable(&ring, &distances).expect("valid");
+        assert!(!baseline.is_empty());
+        for _ in 0..8 {
+            let again = variable(&ring, &distances).expect("valid");
+            assert_eq!(baseline.len(), again.len());
+            for ((o1, h1), (o2, h2)) in baseline.iter().zip(&again) {
+                assert!(same(o1, o2), "outer ring identical across calls");
+                assert_eq!(h1.len(), h2.len());
+            }
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "opengeometry",
-  "version": "2.0.9",
+  "version": "2.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opengeometry",
-      "version": "2.0.9",
+      "version": "2.0.12",
       "license": "MPL-2.0",
       "dependencies": {
-        "tsc": "^2.0.4",
         "uuid": "^10.0.0"
       },
       "devDependencies": {
@@ -3606,14 +3605,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/tsc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.4.tgz",
-      "integrity": "sha512-fzoSieZI5KKJVBYGvwbVZs/J5za84f2lSTLPYf6AGiIf43tZ3GNrI1QzTLcjtyDDP4aLxd46RTZq1nQxe7+k5Q==",
-      "bin": {
-        "tsc": "bin/tsc"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "opengeometry",
   "author": "Vishwajeet Vinayak Mane",
   "license": "MPL-2.0",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "CAD kernel for the web built with Rust, WebAssembly, and Three.js for browser CAD, AEC/BIM, and geometry-heavy tools.",
   "type": "module",
   "main": "index.js",
@@ -63,5 +63,6 @@
     "rollup": "^4.21.3",
     "tslib": "^2.7.0",
     "vite": "^6.2.2"
-  }
+  },
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"
 }


### PR DESCRIPTION
## What

Adds `offsetRingVariable(ring, distances)` — a variable-distance (per-edge) polygon inset — so zoning setbacks (front 6 m / side 1.5 m / rear 3 m) produce a correct buildable envelope.

Before this, the kernel had no ring inset at all: `offsetPolylineRegions` strokes a centreline, it doesn't inset a boundary. Downstream consumers were insetting uniformly at the *deepest* setback, which throws away buildable area on every other edge. On a 20 × 30 m parcel with [6, 1.5, 3, 1.5] that workaround yields 8 × 18 = 144 m²; the correct envelope is 17 × 21 = **357 m² (+148 %)**.

## How

**Stadium subtraction with positive-winding resolution**, not a join-based offset traversal. A join-based inset was implemented first and rejected — tests exposed three real defects:

- an over-deep uniform inset double-inverts into a phantom CCW region that winding rules cannot detect;
- bevel joins claim points closer than the required clearance;
- clearance from a distant edge across a notch (through exterior space) is missed entirely.

Instead, each edge contributes a *forbidden stadium* (rectangle `segment ± d` plus two circumscribed 12-segment tangent fans), wound CW, and the answer is `resolve_polygons_positive([ccw_ring, cw_stadiums…])`.

Because each stadium is convex and strictly contains the exact clearance region, the guarantee holds for **every point** of the output, not just the sampled vertices: no output point is ever closer to edge *i* than `distances[i]`. Caps are circumscribed (radius `d / cos(7.5°)`), so the error is one-directional — the envelope can under-claim by at most 0.86 % of `d` at a corner arc, and can never violate a setback. Convex corners generate no arc at all, so rectangular and L-shaped parcels come out bit-exact.

### No `miterLimit` parameter

Intentionally omitted, against the original spec. There are no miters to limit — corners are clearance arcs, which strictly dominate both alternatives for an inset: a **bevel** provably claims points inside the required distance (a compliance checker would flag the SDK's own envelope), and a **miter** at a sharp reflex corner over-carves and needs a bound. Shipping a dead knob would be dishonest API.

## Behaviour

| Case | Result |
|---|---|
| uniform square inset | exact shrunken square, 4 vertices |
| rect + [6, 1.5, 3, 1.5] | exact corners (1.5, 6)…(18.5, 27) |
| zero-distance edge | edge stays in place (build-to lot line) |
| all-zero distances | input ring returned unchanged |
| collinear split frontage (d=2 then d=5) | transition through the deep edge's clearance arc, not a perpendicular step |
| distant edge across a notch | honoured — envelope is cut back |
| over-deep inset (4×4, all 3) | `Ok(vec![])` — empty, not inverted |
| dumbbell parcel, waist < 2d | exactly 2 disjoint regions |
| count mismatch / negative distance | `Err` / throws (caller bug, not geometry) |
| degenerate ring (<3 pts, zero area, self-intersecting) | empty, never throws |
| determinism | bitwise-identical across calls |

## API

```rust
pub fn offset_ring_variable(ring: &[Vector3], distances: &[f64], eps: f64)
    -> Result<Vec<OffsetRegion>, String>

#[wasm_bindgen(js_name = offsetRingVariable)]
pub fn offset_ring_variable_wasm(ring_flat: Vec<f64>, distances: Vec<f64>)
    -> Result<OGOffsetRegionsResult, JsValue>
```

```ts
export function offsetRingVariable(
  ring: number[] | Float64Array,
  distances: number[] | Float64Array,
): OffsetRegion[];
```

Edge *i* = `ring[i] → ring[i+1]`; a closing duplicate point is accepted and stripped. Output is the existing canonical `OffsetRegion` contract (CW outer / CCW holes, lex-min start vertex) — same as `offsetPolylineRegions`. Returns *several* regions when a deep inset splits the ring.

## Supporting changes

**`boolean2d.rs`** — the `union_polygons_nonzero` body is extracted into a private `winding_regions(polys, eps, filled)`; `union_polygons_nonzero` keeps its behaviour (`winding != 0`), and the new `resolve_polygons_positive` uses `winding > 0` (CCW adds, CW subtracts), keeping every disjoint remainder with holes nested via `ring_inside2`.

Plus a bug-class fix in the shared core: coincident duplicate oriented sub-edges are now deduped. Two stadiums sharing a parcel corner emit byte-identical cap-fan edges; without the dedup the loop stitcher traces the same boundary twice and fabricates a duplicate sliver region. This also hardens the existing nonzero union path.

**IFC export** — `IFCSPACE` / `IFCSITE` added to the allowed classes with their correct spatial-element STEP signatures; spaces aggregate under the scaffold storey and element sites under the project, rather than riding `IFCRELCONTAINEDINSPATIALSTRUCTURE`. Property-set values become typed (`IFCREAL` / `IFCBOOLEAN` / `IFCTEXT`) via an untagged serde enum, so legacy string-only configs still parse. Pset/qset writers now iterate sorted names — HashMap ordering was leaking into the SPF output.

> ⚠️ **Release note:** models that previously requested `IfcSpace` semantics stop degrading to `IFCBUILDINGELEMENTPROXY`. Output bytes change for existing users.

## Versions

`package.json` → 2.0.12, `main/opengeometry/Cargo.toml` → 1.0.10 (bumped together, as release.yml requires). `package-lock.json` also drops a stale `tsc` entry left over from the earlier move of tsc to devDependencies.

## Example

New demo at `examples-vite/operations/offset-ring-variable.html` with live front/side/rear sliders, plus a dumbbell parcel toggle demonstrating the two-region split.

## Test plan

- `cargo test` — **209 lib + 12 integration, 0 failed**. 16 new `variable_inset_*` tests cover the matrix above, including a clearance assertion over every output vertex against every input edge segment.
- `cargo check` — clean
- `npm run lint:check` — clean
- `npm run build` — clean (wasm rebuilt, rollup + prepare-dist green)
- `cargo fmt --check` — 3 files fail (`poly2d.rs`, `lib.rs`, `primitives/elliptical_arc.rs`), all pre-existing on `main` and untouched here. Every file in this PR is fmt-clean.
- ⏳ Browser click-through of the new example page — **not yet done**, the one outstanding check.

## Known limitations (follow-up candidates)

- Cap resolution is a fixed 12 segments, so accuracy is relative to `d` — negligible at residential setbacks (2.6 cm at 3 m), but ~43 cm at a 50 m buffer, and over-tessellated for small distances. An adaptive count from a chord tolerance would bound absolute error and shrink the arrangement.
- `winding_regions` is O(E²) in the edge count, and each stadium adds 28 vertices. Fine for typical parcels; a 100-vertex surveyed boundary would want a sweep-line.
- Input is a single ring — parcels with easements or exclusion zones can't be expressed yet, though the output type already carries holes.
- An empty result doesn't distinguish "setbacks consumed the parcel" from "input polygon is degenerate".
